### PR TITLE
Encode StartAddressPageOffset in 8000H-BFFFH form

### DIFF
--- a/samfile.go
+++ b/samfile.go
@@ -483,7 +483,7 @@ func (di *DiskImage) AddCodeFile(name string, data []byte, loadAddress, executio
 	fe := &FileEntry{
 		Type:                   FT_CODE,
 		StartAddressPage:       uint8(loadAddress>>14) - 1,
-		StartAddressPageOffset: uint16(loadAddress & 0x3fff),
+		StartAddressPageOffset: uint16((loadAddress & 0x3fff) | 0x8000),
 		ExecutionAddressDiv16K: 0xff,
 		ExecutionAddressMod16K: 0xffff,
 	}

--- a/samfile_test.go
+++ b/samfile_test.go
@@ -5,6 +5,79 @@ import (
 	"testing"
 )
 
+// TestAddCodeFile8000HFormPageOffset asserts that AddCodeFile stores the
+// page offset in 8000H-BFFFH form, so disks built with samfile load at
+// the correct address when read by SAMDOS.
+//
+// Tech Manual v3.0 L4326-4329 (file-header section) and L4388-4392
+// (directory-entry section) both specify the encoding:
+//
+//   - Byte 8 (file header) / 236 (directory entry): "starting page
+//     number ... AND this with 1FH to get the page number in the
+//     range 0 to 31".
+//   - Bytes 3-4 (file header) / 237-238 (directory entry): "PAGE
+//     OFFSET (8000-BFFFH)".
+//   - Decode: start = page * 16384 + raw_offset - 0x4000.
+//
+// Empirically confirmed against three real SAMDOS-written disks
+// (CommsLoader.dsk, FileShredderv1.2.dsk, FontLoader.dsk): 38 of 38
+// directory entries have bit 15 set in bytes 0xed/0xee. Without the
+// fix, samfile-written disks load ~16K below the intended address
+// when read by SAMDOS — even though samfile's own reader (which masks
+// `& 0x3fff`) reads them back correctly.
+//
+// This test runs samfile-written stored bytes through the Tech Manual
+// decode formula directly, bypassing samfile's reader-side masking.
+func TestAddCodeFile8000HFormPageOffset(t *testing.T) {
+	cases := []struct {
+		name        string
+		loadAddress uint32
+	}{
+		{"first RAM byte (0x4000)", 0x4000},
+		{"section C boundary (0xC000)", 0xC000},
+		{"FontLoader 'Font Code' equivalent (82000)", 82000},
+		{"end of last RAM page (0x7FFFC)", 0x7FFFC},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			di := &DiskImage{}
+			if err := di.AddCodeFile("F", []byte("test"), c.loadAddress, 0); err != nil {
+				t.Fatalf("AddCodeFile: %v", err)
+			}
+			var fe *FileEntry
+			for _, e := range di.DiskJournal() {
+				if e.Used() && e.Name.String() == "F" {
+					fe = e
+					break
+				}
+			}
+			if fe == nil {
+				t.Fatal("F entry not found in disk journal")
+			}
+			rawOffset := fe.StartAddressPageOffset
+			if rawOffset&0x8000 == 0 {
+				t.Errorf("raw page offset 0x%04x has bit 15 clear; "+
+					"Tech Manual L4390 specifies range 8000-BFFFH",
+					rawOffset)
+			}
+			if rawOffset >= 0xC000 {
+				t.Errorf("raw page offset 0x%04x outside 8000-BFFFH range",
+					rawOffset)
+			}
+			techManualStart := uint32(fe.StartAddressPage&0x1f)*0x4000 +
+				uint32(rawOffset) - 0x4000
+			if techManualStart != c.loadAddress {
+				t.Errorf("Tech Manual decode of stored bytes "+
+					"(page=0x%02x, offset=0x%04x) = 0x%05x; "+
+					"load address was 0x%05x",
+					fe.StartAddressPage, rawOffset,
+					techManualStart, c.loadAddress)
+			}
+		})
+	}
+}
+
+
 // TestSAMMaskExhaustive iterates over every valid data sector — the 1560
 // in the SAM domain (T4..T79 S1..S10 on side 0, T128..T207 S1..S10 on
 // side 1) — and asserts SAMMask returns (bitOffset/8, 1<<(bitOffset%8)).


### PR DESCRIPTION
## Summary

`AddCodeFile` stored the page offset (directory-entry bytes 237-238 / file-header bytes 3-4) without the 0x8000 bit set. Tech Manual v3.0 L4326-4329 and L4388-4392 both specify the field is in the range 8000H-BFFFH, with decode formula:

    start = (stored_page & 0x1f) * 16384 + raw_offset - 0x4000

`samfile-only` round-trips were unaffected because the reader masks `& 0x3fff` and adds the missing page back via the `+1` in `StartAddress()`. But disks written with `samfile add` and then booted on a real SAM Coupé via SAMDOS would load files at `loadAddress - 16384` — i.e. one full 16K page below the intended location.

```diff
-               StartAddressPageOffset: uint16(loadAddress & 0x3fff),
+               StartAddressPageOffset: uint16((loadAddress & 0x3fff) | 0x8000),
```

`ExecutionAddressMod16K` (`samfile.go:492`) already uses `| 0x8000`; this aligns the load-address encoding with the same convention.

## Empirical evidence

Dumped bytes 0xed/0xee of every used directory entry on three SAM-Coupé disks from [ftp.nvg.ntnu.no/pub/sam-coupe/disks/utils/](https://ftp.nvg.ntnu.no/pub/sam-coupe/disks/utils/):

| Disk | bit-15 set | bit-15 clear |
|---|---|---|
| CommsLoader.dsk (SAMDOS-written) | 3 | 0 |
| FileShredderv1.2.dsk (SAMDOS-written) | 5 | 0 |
| FontLoader.dsk (SAMDOS-written) | 30 | 0 |
| Pre-fix samfile-written | 0 | 2 |

**38/38 SAMDOS entries set the bit; 2/2 pre-fix samfile entries clear it.** Strong, unambiguous signal.

After the fix, samfile-written entries match SAMDOS form:

```
$ samfile add -i post-fix.mgt -f A -c -l 82000     # = 0x14050
$ samfile add -i post-fix.mgt -f B -c -l 20880     # = 0x05190
A: page=0x04 offset=0x8050 bit15=SET TM_decode=82000
B: page=0x00 offset=0x9190 bit15=SET TM_decode=20880
```

Compare to FontLoader.dsk's "Font Code" entry (load 82000): `page=0x64` (bits 5-7 are "undefined" per Tech Manual L4388, bits 0-4 = 0x04), `offset=0x8050` — bits 0-4 of page and the full offset match exactly.

## Test plan

`TestAddCodeFile8000HFormPageOffset` runs `AddCodeFile` for four load addresses across the valid range and decodes the stored bytes via the Tech Manual formula directly (bypassing samfile's masking-tolerant reader). Cases:

- `0x4000` — first RAM byte
- `0xC000` — section C boundary
- `82000` (`0x14050`) — same load address as FontLoader's "Font Code"
- `0x7FFFC` — end of last RAM page

Red-green verified: all four sub-tests fail without the fix, all pass with it.

```
$ go test -count=1 ./...
ok      github.com/petemoore/samfile/v2 0.454s
ok      github.com/petemoore/samfile/v2/cmd/samfile     0.605s
```

samfile's reader is unchanged. Existing tests confirm both encoded forms still read correctly:
- `TestCatEnolaGayFileFromETrackerDisk` reads from a SAMDOS-written disk (bit 15 set on disk)
- `TestAddFileMultiFileNoCorruption` reads from a samfile-written disk (now also bit 15 set)
