### PR TITLE
Decode SAM BASIC lengths in PAGEFORM, reshape API around section sizes, bump v3

### DIFF
--- a/cmd/samfile/add.go
+++ b/cmd/samfile/add.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strconv"
 
-	"github.com/petemoore/samfile/v2"
+	"github.com/petemoore/samfile/v3"
 )
 
 func add(arguments map[string]interface{}) {

--- a/cmd/samfile/cat.go
+++ b/cmd/samfile/cat.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/petemoore/samfile/v2"
+	"github.com/petemoore/samfile/v3"
 )
 
 func cat(arguments map[string]interface{}) {

--- a/cmd/samfile/extract.go
+++ b/cmd/samfile/extract.go
@@ -6,7 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/petemoore/samfile/v2"
+	"github.com/petemoore/samfile/v3"
 )
 
 func extract(arguments map[string]interface{}) {

--- a/cmd/samfile/ls.go
+++ b/cmd/samfile/ls.go
@@ -3,7 +3,7 @@ package main
 import (
 	"log"
 
-	"github.com/petemoore/samfile/v2"
+	"github.com/petemoore/samfile/v3"
 )
 
 func ls(arguments map[string]interface{}) {

--- a/cmd/samfile/sambasic.go
+++ b/cmd/samfile/sambasic.go
@@ -5,7 +5,7 @@ import (
 	"io"
 	"os"
 
-	"github.com/petemoore/samfile/v2"
+	"github.com/petemoore/samfile/v3"
 )
 
 func basicToText(arguments map[string]interface{}) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/petemoore/samfile/v2
+module github.com/petemoore/samfile/v3
 
 go 1.19
 

--- a/samfile.go
+++ b/samfile.go
@@ -392,16 +392,28 @@ func (fe *FileEntry) Output() error {
 	return nil
 }
 
+// pageFormLength decodes a 19-bit length stored in SAM Coupé "PAGEFORM":
+// byte 0 is a page count (16384 bytes per page); bytes 1-2 are a
+// little-endian 16-bit address in section C (0x8000-0xBFFF) whose low
+// 14 bits carry the in-page offset (bit 15 is always 1 by SCF;RR H,
+// bit 14 always 0). The linear length is therefore
+// page * 16384 + (raw_addr & 0x3fff). See ROM disasm RDTHREE
+// (sam-coupe_rom-v3.0_annotated-disassembly.txt:7654-7659) and PAGEFORM
+// (sam-coupe_rom-v3.0_annotated-disassembly.txt:7578-7589).
+func pageFormLength(b0, b1, b2 byte) uint32 {
+	return uint32(b0)*16384 + uint32(uint16(b1)|uint16(b2)<<8)&0x3fff
+}
+
 func (fe *FileEntry) ProgramLength() uint32 {
-	return uint32(fe.FileTypeInfo[0])<<16 | uint32(fe.FileTypeInfo[1]) | uint32(fe.FileTypeInfo[2])<<8
+	return pageFormLength(fe.FileTypeInfo[0], fe.FileTypeInfo[1], fe.FileTypeInfo[2])
 }
 
 func (fe *FileEntry) NumericVariableOffset() uint32 {
-	return uint32(fe.FileTypeInfo[3])<<16 | uint32(fe.FileTypeInfo[4]) | uint32(fe.FileTypeInfo[5])<<8
+	return pageFormLength(fe.FileTypeInfo[3], fe.FileTypeInfo[4], fe.FileTypeInfo[5])
 }
 
 func (fe *FileEntry) StringArrayVariableOffset() uint32 {
-	return uint32(fe.FileTypeInfo[6])<<16 | uint32(fe.FileTypeInfo[7]) | uint32(fe.FileTypeInfo[8])<<8
+	return pageFormLength(fe.FileTypeInfo[6], fe.FileTypeInfo[7], fe.FileTypeInfo[8])
 }
 
 func (fe *FileEntry) ExecutionAddress() uint32 {

--- a/samfile.go
+++ b/samfile.go
@@ -376,8 +376,9 @@ func (fe *FileEntry) Output() error {
 		fmt.Printf("  Screen Mode:                       %v\n", fe.FileTypeInfo[0])
 	case FT_SAM_BASIC:
 		fmt.Printf("  Program length:                    %v\n", fe.ProgramLength())
-		fmt.Printf("  Numeric variables offset:          %v\n", fe.NumericVariableOffset())
-		fmt.Printf("  String/array variables offset:     %v\n", fe.StringArrayVariableOffset())
+		fmt.Printf("  Numeric variables size:            %v\n", fe.NumericVariablesSize())
+		fmt.Printf("  Gap size:                          %v\n", fe.GapSize())
+		fmt.Printf("  String/array variables size:       %v\n", fe.StringArrayVariablesSize())
 	}
 	fmt.Printf("  Start:                             %v\n", fe.StartAddress())
 	fmt.Printf("  Length:                            %v\n", fe.Length())
@@ -404,16 +405,40 @@ func pageFormLength(b0, b1, b2 byte) uint32 {
 	return uint32(b0)*16384 + uint32(uint16(b1)|uint16(b2)<<8)&0x3fff
 }
 
+// SAM BASIC file layout (program area, in order):
+//   [program text] [numeric variables] [gap] [string/array variables]
+// The three FileTypeInfo length fields encode the cumulative offsets of the
+// section boundaries; the four section sizes below are derived from them
+// plus the file's total Length, and are easier for callers to reason
+// about than the raw cumulative offsets. Per Tech Manual L4370-4382 and
+// ROM disasm L16005-16012 ("CDE=LEN OF PROG ALONE" / "CDE=LEN OF
+// PROG+NVARS+GAP").
+
+// ProgramLength is the size in bytes of the SAM BASIC program text,
+// excluding any variables.
 func (fe *FileEntry) ProgramLength() uint32 {
 	return pageFormLength(fe.FileTypeInfo[0], fe.FileTypeInfo[1], fe.FileTypeInfo[2])
 }
 
-func (fe *FileEntry) NumericVariableOffset() uint32 {
-	return pageFormLength(fe.FileTypeInfo[3], fe.FileTypeInfo[4], fe.FileTypeInfo[5])
+// NumericVariablesSize is the size in bytes of the numeric variables
+// section that immediately follows the program text.
+func (fe *FileEntry) NumericVariablesSize() uint32 {
+	return pageFormLength(fe.FileTypeInfo[3], fe.FileTypeInfo[4], fe.FileTypeInfo[5]) -
+		pageFormLength(fe.FileTypeInfo[0], fe.FileTypeInfo[1], fe.FileTypeInfo[2])
 }
 
-func (fe *FileEntry) StringArrayVariableOffset() uint32 {
-	return pageFormLength(fe.FileTypeInfo[6], fe.FileTypeInfo[7], fe.FileTypeInfo[8])
+// GapSize is the size in bytes of the gap that SAM BASIC leaves between
+// the numeric variables and the string/array variables.
+func (fe *FileEntry) GapSize() uint32 {
+	return pageFormLength(fe.FileTypeInfo[6], fe.FileTypeInfo[7], fe.FileTypeInfo[8]) -
+		pageFormLength(fe.FileTypeInfo[3], fe.FileTypeInfo[4], fe.FileTypeInfo[5])
+}
+
+// StringArrayVariablesSize is the size in bytes of the string and array
+// variables section, which occupies the remainder of the file after the
+// gap.
+func (fe *FileEntry) StringArrayVariablesSize() uint32 {
+	return fe.Length() - pageFormLength(fe.FileTypeInfo[6], fe.FileTypeInfo[7], fe.FileTypeInfo[8])
 }
 
 func (fe *FileEntry) ExecutionAddress() uint32 {

--- a/samfile_test.go
+++ b/samfile_test.go
@@ -6,91 +6,99 @@ import (
 )
 
 // TestFileTypeInfoPageFormDecoding pins down the SAM Coupé "PAGEFORM"
-// encoding of the three SAM-BASIC FileTypeInfo length fields.
+// encoding of the three SAM-BASIC FileTypeInfo length fields, and the
+// four section sizes derived from them.
 //
-// The ROM's RDTHREE helper at sam-coupe_rom-v3.0_annotated-disassembly.txt:
-// 7654-7659 reads three bytes from a directory entry into Z80 registers
-// (C, E, D) — i.e. byte 0 → page register, bytes 1-2 → little-endian
-// 16-bit address. PAGEFORM (sam-coupe_rom-v3.0_annotated-disassembly.txt:
-// 7578-7589) then treats that as a 19-bit linear value: page * 16384 +
-// (address - 0x8000), with bit 15 of the address always 1 (set by SCF;
-// RR H) and bit 14 always 0. So the linear length is
+// The on-disk encoding stores three cumulative offsets (end of program,
+// end of numeric variables, end of gap). Each is a 19-bit length in
+// PAGEFORM: byte 0 = page count (16384 each), bytes 1-2 = LE address in
+// section C with low 14 bits significant. See ROM disasm RDTHREE
+// (sam-coupe_rom-v3.0_annotated-disassembly.txt:7654-7659) and PAGEFORM
+// (sam-coupe_rom-v3.0_annotated-disassembly.txt:7578-7589).
 //
-//     page*16384 + (raw_addr & 0x3fff)
-//
-// Tech Manual L4370-4382 names the three fields ("program length
-// excluding variables", "...plus numeric variables", "...plus numeric
-// variables and the gap before string and array variables") but is
-// silent on the byte encoding; the ROM disasm resolves the ambiguity.
+// The four section sizes (program, numeric vars, gap, string/array
+// vars) must sum to the file's total Length — that's the structural
+// invariant we check on every fixture below.
 //
 // Falsification fixtures: bytes captured directly from real SAMDOS-
 // written BASIC files on disks downloaded from
-// ftp.nvg.ntnu.no/pub/sam-coupe/disks/utils/. Each file's third length
-// (PROG+NVARS+GAP) must be ≤ the file's total Length, and for programs
-// with no string/array variables it equals Length exactly.
+// ftp.nvg.ntnu.no/pub/sam-coupe/disks/utils/. Tech Manual L4370-4382
+// describes the fields as cumulative lengths.
 func TestFileTypeInfoPageFormDecoding(t *testing.T) {
 	cases := []struct {
-		name        string
-		info        [11]byte
-		fileLength  uint32
-		wantProgLen uint32
-		wantNumVar  uint32
-		wantStrArr  uint32
+		name         string
+		info         [11]byte
+		pages        uint8
+		lengthMod16K uint16
+		wantProgLen  uint32
+		wantNVarsSz  uint32
+		wantGapSz    uint32
+		wantSAVSz    uint32
 	}{
 		{
-			name:        "Auto Font (FontLoader.dsk, no string/array vars)",
-			info:        [11]byte{0x01, 0xc3, 0x8c, 0x01, 0x0d, 0x8e, 0x01, 0x1f, 0x8f, 0x20, 0xff},
-			fileLength:  20255,
-			wantProgLen: 19651,
-			wantNumVar:  19981,
-			wantStrArr:  20255,
+			name:         "Auto Font (FontLoader.dsk, no string/array vars)",
+			info:         [11]byte{0x01, 0xc3, 0x8c, 0x01, 0x0d, 0x8e, 0x01, 0x1f, 0x8f, 0x20, 0xff},
+			pages:        1,
+			lengthMod16K: 0x0f1f, // total Length = 20255
+			wantProgLen:  19651,
+			wantNVarsSz:  330,
+			wantGapSz:    274,
+			wantSAVSz:    0,
 		},
 		{
-			name:        "Shredder (FileShredderv1.2.dsk, no string/array vars)",
-			info:        [11]byte{0x00, 0xbf, 0x9b, 0x00, 0x3a, 0x9c, 0x00, 0x1b, 0x9e},
-			fileLength:  7707,
-			wantProgLen: 7103,
-			wantNumVar:  7226,
-			wantStrArr:  7707,
+			name:         "Shredder (FileShredderv1.2.dsk, no string/array vars)",
+			info:         [11]byte{0x00, 0xbf, 0x9b, 0x00, 0x3a, 0x9c, 0x00, 0x1b, 0x9e},
+			pages:        0,
+			lengthMod16K: 0x1e1b, // total Length = 7707
+			wantProgLen:  7103,
+			wantNVarsSz:  123,
+			wantGapSz:    481,
+			wantSAVSz:    0,
 		},
 		{
-			name:        "AUTOCOMMS (CommsLoader.dsk)",
-			info:        [11]byte{0x00, 0x22, 0x9f, 0x00, 0x30, 0xa0, 0x00, 0x7e, 0xa1},
-			fileLength:  8861,
-			wantProgLen: 7970,
-			wantNumVar:  8240,
-			wantStrArr:  8574,
+			name:         "AUTOCOMMS (CommsLoader.dsk, has string/array vars)",
+			info:         [11]byte{0x00, 0x22, 0x9f, 0x00, 0x30, 0xa0, 0x00, 0x7e, 0xa1},
+			pages:        0,
+			lengthMod16K: 0x229d, // total Length = 8861
+			wantProgLen:  7970,
+			wantNVarsSz:  270,
+			wantGapSz:    334,
+			wantSAVSz:    287,
 		},
 		{
-			name:        "synthetic page=0, addr=0x8000",
-			info:        [11]byte{0x00, 0x00, 0x80, 0x00, 0x00, 0x80, 0x00, 0x00, 0x80},
-			wantProgLen: 0,
-			wantNumVar:  0,
-			wantStrArr:  0,
-		},
-		{
-			name:        "synthetic page=31, addr=0xBFFF (max)",
-			info:        [11]byte{0x1f, 0xff, 0xbf, 0x1f, 0xff, 0xbf, 0x1f, 0xff, 0xbf},
-			wantProgLen: 0x7FFFF,
-			wantNumVar:  0x7FFFF,
-			wantStrArr:  0x7FFFF,
+			name:         "empty: page=0 addr=0x8000 throughout, total=0",
+			info:         [11]byte{0x00, 0x00, 0x80, 0x00, 0x00, 0x80, 0x00, 0x00, 0x80},
+			pages:        0,
+			lengthMod16K: 0,
+			wantProgLen:  0,
+			wantNVarsSz:  0,
+			wantGapSz:    0,
+			wantSAVSz:    0,
 		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			fe := &FileEntry{FileTypeInfo: c.info}
+			fe := &FileEntry{
+				FileTypeInfo: c.info,
+				Pages:        c.pages,
+				LengthMod16K: c.lengthMod16K,
+			}
 			if got := fe.ProgramLength(); got != c.wantProgLen {
 				t.Errorf("ProgramLength = %d; want %d", got, c.wantProgLen)
 			}
-			if got := fe.NumericVariableOffset(); got != c.wantNumVar {
-				t.Errorf("NumericVariableOffset = %d; want %d", got, c.wantNumVar)
+			if got := fe.NumericVariablesSize(); got != c.wantNVarsSz {
+				t.Errorf("NumericVariablesSize = %d; want %d", got, c.wantNVarsSz)
 			}
-			if got := fe.StringArrayVariableOffset(); got != c.wantStrArr {
-				t.Errorf("StringArrayVariableOffset = %d; want %d", got, c.wantStrArr)
+			if got := fe.GapSize(); got != c.wantGapSz {
+				t.Errorf("GapSize = %d; want %d", got, c.wantGapSz)
 			}
-			if c.fileLength != 0 && fe.ProgramLength() > c.fileLength {
-				t.Errorf("sanity: ProgramLength %d > file Length %d (impossible)",
-					fe.ProgramLength(), c.fileLength)
+			if got := fe.StringArrayVariablesSize(); got != c.wantSAVSz {
+				t.Errorf("StringArrayVariablesSize = %d; want %d", got, c.wantSAVSz)
+			}
+			sum := fe.ProgramLength() + fe.NumericVariablesSize() +
+				fe.GapSize() + fe.StringArrayVariablesSize()
+			if sum != fe.Length() {
+				t.Errorf("section sizes sum to %d; want fe.Length() = %d", sum, fe.Length())
 			}
 		})
 	}

--- a/samfile_test.go
+++ b/samfile_test.go
@@ -5,6 +5,98 @@ import (
 	"testing"
 )
 
+// TestFileTypeInfoPageFormDecoding pins down the SAM Coupé "PAGEFORM"
+// encoding of the three SAM-BASIC FileTypeInfo length fields.
+//
+// The ROM's RDTHREE helper at sam-coupe_rom-v3.0_annotated-disassembly.txt:
+// 7654-7659 reads three bytes from a directory entry into Z80 registers
+// (C, E, D) — i.e. byte 0 → page register, bytes 1-2 → little-endian
+// 16-bit address. PAGEFORM (sam-coupe_rom-v3.0_annotated-disassembly.txt:
+// 7578-7589) then treats that as a 19-bit linear value: page * 16384 +
+// (address - 0x8000), with bit 15 of the address always 1 (set by SCF;
+// RR H) and bit 14 always 0. So the linear length is
+//
+//     page*16384 + (raw_addr & 0x3fff)
+//
+// Tech Manual L4370-4382 names the three fields ("program length
+// excluding variables", "...plus numeric variables", "...plus numeric
+// variables and the gap before string and array variables") but is
+// silent on the byte encoding; the ROM disasm resolves the ambiguity.
+//
+// Falsification fixtures: bytes captured directly from real SAMDOS-
+// written BASIC files on disks downloaded from
+// ftp.nvg.ntnu.no/pub/sam-coupe/disks/utils/. Each file's third length
+// (PROG+NVARS+GAP) must be ≤ the file's total Length, and for programs
+// with no string/array variables it equals Length exactly.
+func TestFileTypeInfoPageFormDecoding(t *testing.T) {
+	cases := []struct {
+		name        string
+		info        [11]byte
+		fileLength  uint32
+		wantProgLen uint32
+		wantNumVar  uint32
+		wantStrArr  uint32
+	}{
+		{
+			name:        "Auto Font (FontLoader.dsk, no string/array vars)",
+			info:        [11]byte{0x01, 0xc3, 0x8c, 0x01, 0x0d, 0x8e, 0x01, 0x1f, 0x8f, 0x20, 0xff},
+			fileLength:  20255,
+			wantProgLen: 19651,
+			wantNumVar:  19981,
+			wantStrArr:  20255,
+		},
+		{
+			name:        "Shredder (FileShredderv1.2.dsk, no string/array vars)",
+			info:        [11]byte{0x00, 0xbf, 0x9b, 0x00, 0x3a, 0x9c, 0x00, 0x1b, 0x9e},
+			fileLength:  7707,
+			wantProgLen: 7103,
+			wantNumVar:  7226,
+			wantStrArr:  7707,
+		},
+		{
+			name:        "AUTOCOMMS (CommsLoader.dsk)",
+			info:        [11]byte{0x00, 0x22, 0x9f, 0x00, 0x30, 0xa0, 0x00, 0x7e, 0xa1},
+			fileLength:  8861,
+			wantProgLen: 7970,
+			wantNumVar:  8240,
+			wantStrArr:  8574,
+		},
+		{
+			name:        "synthetic page=0, addr=0x8000",
+			info:        [11]byte{0x00, 0x00, 0x80, 0x00, 0x00, 0x80, 0x00, 0x00, 0x80},
+			wantProgLen: 0,
+			wantNumVar:  0,
+			wantStrArr:  0,
+		},
+		{
+			name:        "synthetic page=31, addr=0xBFFF (max)",
+			info:        [11]byte{0x1f, 0xff, 0xbf, 0x1f, 0xff, 0xbf, 0x1f, 0xff, 0xbf},
+			wantProgLen: 0x7FFFF,
+			wantNumVar:  0x7FFFF,
+			wantStrArr:  0x7FFFF,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fe := &FileEntry{FileTypeInfo: c.info}
+			if got := fe.ProgramLength(); got != c.wantProgLen {
+				t.Errorf("ProgramLength = %d; want %d", got, c.wantProgLen)
+			}
+			if got := fe.NumericVariableOffset(); got != c.wantNumVar {
+				t.Errorf("NumericVariableOffset = %d; want %d", got, c.wantNumVar)
+			}
+			if got := fe.StringArrayVariableOffset(); got != c.wantStrArr {
+				t.Errorf("StringArrayVariableOffset = %d; want %d", got, c.wantStrArr)
+			}
+			if c.fileLength != 0 && fe.ProgramLength() > c.fileLength {
+				t.Errorf("sanity: ProgramLength %d > file Length %d (impossible)",
+					fe.ProgramLength(), c.fileLength)
+			}
+		})
+	}
+}
+
+
 // TestAddCodeFile8000HFormPageOffset asserts that AddCodeFile stores the
 // page offset in 8000H-BFFFH form, so disks built with samfile load at
 // the correct address when read by SAMDOS.


### PR DESCRIPTION
**Three commits, one logical change**: fix the SAM BASIC `FileTypeInfo` decoding bug (commit 1), then reshape the API around the natural sections of a BASIC file (commit 2), then move the module path to v3 since commit 2 is breaking (commit 3). After merge: tag `v3.0.0`.

## 1. PAGEFORM decoding fix (`6e270db`)

The three `FileTypeInfo` accessors decoded the bytes as a plain 24-bit number with bytes 1 and 2 swapped. The SAM Coupé ROM stores them in **PAGEFORM**: byte 0 = page count (×16384), bytes 1-2 = LE 16-bit address in section C (`0x8000`-`0xBFFF`) whose low 14 bits are the in-page offset.

ROM citations (spot-checked against the file):
- `RDTHREE` (`sam-coupe_rom-v3.0_annotated-disassembly.txt:7654-7659`) reads three bytes into Z80 registers `C, E, D` — i.e. byte 0 → page register, bytes 1-2 → LE 16-bit address.
- `PAGEFORM` (`sam-coupe_rom-v3.0_annotated-disassembly.txt:7578-7589`) defines the encoding: `SCF; RR H` forces bit 15 of the address to 1, bit 14 to 0, so `linear = page*16384 + (addr & 0x3fff)`.
- `MERGE` (`sam-coupe_rom-v3.0_annotated-disassembly.txt:16005-16012`) reads bytes 16-18 and 22-24 of the in-memory header via `RDTHREE` and labels them "CDE=LEN OF PROG ALONE" and "CDE=LEN OF PROG+NVARS+GAP" — confirming the same encoding for the directory's UIFA bytes 16-24.

Tech Manual `sam-coupe_tech-man_v3-0.txt:4370-4382` names the fields but is silent on the encoding; the ROM disasm resolves it.

**Empirical proof:** the pre-fix decoder reported `Program length` values *larger than the file Length* on every real-disk fixture — physically impossible. After the fix, all values are sane:

| | file Length | PROG (was) | (now) |
|---|---|---|---|
| Auto Font (FontLoader.dsk) | 20255 | **101571** ❌ | 19651 ✅ |
| Shredder (FileShredderv1.2.dsk) | 7707 | **39871** ❌ | 7103 ✅ |
| AUTOCOMMS (CommsLoader.dsk) | 8861 | **40738** ❌ | 7970 ✅ |

## 2. Reshape API around section sizes (`efc0a7e`)

The on-disk encoding stores three cumulative offsets that mark the three boundaries between four sections of a BASIC file:

```
[program text] [numeric variables] [gap] [string/array variables]
```

The previous accessor names (`ProgramLength`, `NumericVariableOffset`, `StringArrayVariableOffset`) exposed only two of those three boundaries and were asymmetric — `NumericVariableOffset` returned where numeric vars *end* (= where the gap *starts*), while `StringArrayVariableOffset` returned where string/array vars *start*. Net effect: the gap was invisible at the API surface and callers had to know which boundary each name referred to.

Replaced with four orthogonal section-size accessors:

| Method | Meaning |
|---|---|
| `ProgramLength()` | size of program text (kept) |
| `NumericVariablesSize()` | size of numeric variables (new) |
| `GapSize()` | size of the gap (new) |
| `StringArrayVariablesSize()` | size of string/array vars (new) |
| (existing `Length()`) | total file length |

Removed: `NumericVariableOffset()`, `StringArrayVariableOffset()`.

Display in `samfile ls` for SAM BASIC files now reads (Auto Font, FontLoader.dsk):

```
  Program length:                    19651
  Numeric variables size:            330
  Gap size:                          274
  String/array variables size:       0
  Length:                            20255
```

The four section sizes always sum to `Length()` — that's the structural invariant the test asserts on every fixture.

## 3. Module path bump v2 → v3 (`710caa7`)

Commit 2 is breaking. `pkg.go.dev` reports zero importers of `v2`; the only external GitHub mention (`stripwax/SamPuzznic`) just invokes the CLI binary. So the bump is academic — but principled. Anyone pinned to `v2.x.x` continues to get `v2.x.x`.

After merge: tag `v3.0.0`.

## Test plan

`TestFileTypeInfoPageFormDecoding` — table test with four fixtures (three real BASIC files + one empty-everything synthetic), asserting each of the four section sizes plus the structural invariant that they sum to `fe.Length()`.

```
$ go test -count=1 ./...
ok  github.com/petemoore/samfile/v3  0.517s
ok  github.com/petemoore/samfile/v3/cmd/samfile  0.639s
```

Real-disk validation, before/after `samfile ls`:

```
"Auto Font"  (FontLoader.dsk, file Length 20255)
  before: Program length: 101571   String/array variables offset: 102175
  after:  Program length:  19651   Numeric variables size:        330
                                   Gap size:                      274
                                   String/array variables size:   0
                                   Length:                        20255   (= 19651+330+274+0)

"AUTOCOMMS"  (CommsLoader.dsk, file Length 8861) — only fixture with non-zero string/array vars
  after:  Program length:   7970
          Numeric variables size:        270
          Gap size:                      334
          String/array variables size:   287
          Length:                        8861   (= 7970+270+334+287)
```
