### PR TITLE
Add godoc comments for package, types, and exported API

### DIFF
--- a/cmd/samfile/main.go
+++ b/cmd/samfile/main.go
@@ -1,3 +1,10 @@
+// Command samfile manipulates files inside a SAM Coupé MGT floppy
+// disk image: listing the directory (ls), extracting one or all
+// files (cat / extract), adding a new code file (add), and
+// detokenising a saved SAM BASIC program to plain text
+// (basic-to-text). Run `samfile --help` for invocation details. For
+// programmatic access to MGT images, import the parent package
+// github.com/petemoore/samfile/v3.
 package main
 
 import (

--- a/keywords.go
+++ b/keywords.go
@@ -1,5 +1,13 @@
 package samfile
 
+// keywords is the SAM BASIC v3 keyword token table, indexed by
+// (token_byte − 0x3B). Tokens 0x85..0xF6 are direct single-byte
+// keywords; the two-byte form 0xFF, <idx> extends the table for
+// keywords whose first byte would clash with printable ASCII. Used
+// by SAMBasic.Output to detokenise saved BASIC programs.
+//
+// "<<Reserved>>" entries are slots the ROM never emits — present
+// here only so the index arithmetic lines up with the byte values.
 var (
 	keywords = []string{
 		"PI",

--- a/sambasic.go
+++ b/sambasic.go
@@ -6,17 +6,41 @@ import (
 )
 
 type (
+	// SAMBasic wraps the body bytes of a SAM BASIC (FT_SAM_BASIC,
+	// type 16) file so they can be detokenised back into a plain
+	// text listing. Data must be the file body without its 9-byte
+	// FileHeader prefix — i.e. the Body field of a File returned
+	// by DiskImage.File, or equivalent.
+	//
+	// The body is a sequence of tokenised lines terminated by a
+	// 0xFF end-of-program sentinel. Each line has a 2-byte
+	// big-endian line number, a 2-byte little-endian body length,
+	// the tokenised body and a 0x0D line terminator. Keyword
+	// tokens are single bytes in the range 0x85..0xF6 or the
+	// two-byte sequence 0xFF, <idx>; numeric literals carry a
+	// 5-byte "invisible" floating-point representation introduced
+	// by 0x0E (which Output silently skips).
 	SAMBasic struct {
 		Data []byte
 	}
 )
 
+// NewSAMBasic wraps a SAM BASIC body for detokenisation. data is
+// taken by reference, not copied.
 func NewSAMBasic(data []byte) *SAMBasic {
 	return &SAMBasic{
 		Data: data,
 	}
 }
 
+// Output writes basic.Data as a plain-text BASIC listing to stdout:
+// each line is prefixed with a 5-space-padded decimal line number,
+// keyword tokens are expanded via the v3 SAM BASIC keyword table,
+// the invisible 5-byte numeric form after each 0x0E byte is
+// skipped, and 0x0D becomes a newline. Control characters below
+// 0x20 (other than 0x0D and 0x0E) are rendered as "{N}". Returns
+// an error if the input is empty, truncated, or contains an
+// out-of-range keyword index.
 func (basic *SAMBasic) Output() error {
 	if len(basic.Data) == 0 {
 		return fmt.Errorf("basic-to-text: empty input; expected SAM BASIC bytes on stdin")

--- a/samfile.go
+++ b/samfile.go
@@ -1,5 +1,45 @@
-// See https://www.worldofsam.org/products/samdos and https://sam.speccy.cz/systech/sam-coupe_tech-man_v3-0.pdf
-// for details of the disk format
+// Package samfile reads, inspects and modifies individual files inside a
+// SAM Coupé MGT floppy disk image (the 819200-byte .mgt format written by
+// SAMDOS and used by the SAM emulator ecosystem). For whole-disk
+// operations and format conversions, use samdisk
+// (https://simonowen.com/samdisk/) instead — samfile only touches the
+// contents of an existing image.
+//
+// # MGT image layout
+//
+// An MGT image is 80 cylinders × 2 sides × 10 sectors × 512 bytes,
+// stored cylinder-interleaved (side 0 of each cylinder followed by side
+// 1). Sides are encoded in bit 7 of the track byte: tracks 0–79 are
+// side 0, tracks 128–207 are side 1. Tracks 0–3 of side 0 hold the
+// SAMDOS directory; tracks 4–79 and 128–207 hold file bodies.
+//
+// The directory is 80 fixed-position slots, each 256 bytes, packed two
+// per sector. Every slot is a [FileEntry] describing one file (or sits
+// erased with a zero Type byte). The data area is a pool of 1560
+// 512-byte sectors; a file occupies a chain of sectors whose payload is
+// the first 510 bytes of each sector, with bytes 510–511 holding the
+// (track, sector) link to the next sector ((0, 0) marks end-of-file).
+//
+// # API model
+//
+//   - [Load] reads an .mgt file into a [*DiskImage] (and rejects EDSK
+//     format, which must be converted with samdisk first).
+//   - [DiskImage.DiskJournal] parses the 80-slot directory into a
+//     [*DiskJournal] of [*FileEntry].
+//   - [DiskImage.File] walks the sector chain for a named file and
+//     returns its assembled [*File] (9-byte [FileHeader] + body bytes).
+//   - [DiskImage.AddCodeFile] writes a new code/data file to a free
+//     slot and free sectors, updating both the directory and the
+//     sector chain.
+//   - [DiskImage.Save] writes the (possibly modified) image back to
+//     disk.
+//
+// SAM BASIC programs are stored tokenised; [SAMBasic.Output]
+// detokenises a body into a plain-text listing.
+//
+// Authoritative format references: the SAM Coupé Technical Manual v3.0
+// (https://sam.speccy.cz/systech/sam-coupe_tech-man_v3-0.pdf), the
+// annotated SAM ROM v3.0 disassembly, and the SAMDOS source.
 package samfile
 
 import (
@@ -13,42 +53,127 @@ import (
 )
 
 type (
+	// FileType is the value of the status / file-type byte at offset
+	// 0x00 of a directory entry (and offset 0 of the file body). A
+	// value of 0 marks the slot erased; valid file types are listed
+	// in the FT_* constants. SAMDOS also uses bit 7 of this byte for
+	// HIDDEN and bit 6 for PROTECTED — those attribute bits are not
+	// modelled by FileType and must be masked off before comparing.
 	FileType uint8
 
+	// DiskImage is the raw byte image of one MGT floppy: 80
+	// cylinders × 2 sides × 10 sectors × 512 bytes, stored
+	// cylinder-interleaved (see the package overview). Use Load and
+	// Save to read and write it; use SectorData, DiskJournal, File
+	// and AddCodeFile to read or modify its contents.
 	DiskImage [819200]byte
 
+	// SectorData is the 512 bytes of one disk sector. For data
+	// sectors, the first 510 bytes are file payload and bytes
+	// 510–511 are the (track, sector) link to the next sector in the
+	// chain (see FilePart). For directory sectors, all 512 bytes
+	// belong to two packed FileEntry slots.
 	SectorData [512]byte
 
+	// FileEntry is a parsed 256-byte SAMDOS directory entry. The
+	// disk holds 80 such entries — packed two per sector across
+	// tracks 0–3 of side 0 — and an entry describes either an
+	// existing file or a free slot (Type == 0). The struct fields
+	// mirror the on-disk byte layout one-for-one; see FileEntryFrom
+	// for the byte map.
+	//
+	// StartAddressPage, StartAddressPageOffset, Pages and
+	// LengthMod16K are duplicates of the first 5 of the 9 bytes of
+	// the file body's FileHeader — written into the directory at
+	// SAVE time so that LS-style operations don't have to read the
+	// file body. They should always match the body header.
 	FileEntry struct {
-		Type                   FileType
-		Name                   Filename
-		Sectors                uint16
-		FirstSector            *Sector
-		SectorAddressMap       *SectorAddressMap
+		Type        FileType
+		Name        Filename
+		Sectors     uint16 // big-endian on disk: count of 512-byte sectors the file occupies
+		FirstSector *Sector
+		// SectorAddressMap is the per-file 1560-bit bitmap of which
+		// data sectors this file occupies (see [SectorAddressMap]).
+		SectorAddressMap *SectorAddressMap
+		// FileTypeInfo is the 11-byte type-dependent metadata block
+		// at directory bytes 0xDD–0xE7. For FT_SAM_BASIC it holds
+		// three 3-byte PAGEFORM length triplets (program / +numeric
+		// vars / +gap); for FT_SCREEN, byte 0 is the screen MODE;
+		// for FT_NUM_ARRAY and FT_STR_ARRAY it holds the array's
+		// type/length byte plus name; for FT_CODE it is unused.
 		FileTypeInfo           [11]byte
-		StartAddressPage       uint8
-		StartAddressPageOffset uint16
-		Pages                  uint8
-		LengthMod16K           uint16
+		StartAddressPage       uint8  // mirror of FileHeader.StartPage
+		StartAddressPageOffset uint16 // mirror of FileHeader.PageOffset
+		Pages                  uint8  // mirror of FileHeader.Pages
+		LengthMod16K           uint16 // mirror of FileHeader.LengthMod16K
+		// ExecutionAddressDiv16K and ExecutionAddressMod16K together
+		// encode the auto-execution address of an FT_CODE file in
+		// SAM's REL PAGE FORM. Set ExecutionAddressDiv16K = 0xFF to
+		// disable auto-exec; see ExecutionAddress for the decoded
+		// linear address.
 		ExecutionAddressDiv16K uint8
 		ExecutionAddressMod16K uint16
-		SAMBASICStartLine      uint16
-		MGTFlags               uint8
-		MGTFutureAndPast       [10]byte
-		ReservedA              [4]byte
-		ReservedB              [11]byte
+		// SAMBASICStartLine occupies the same two bytes as
+		// ExecutionAddressMod16K: for FT_SAM_BASIC it is the
+		// auto-RUN line number (or 0xFFFF / ExecutionAddressDiv16K =
+		// 0xFF to opt out of auto-RUN).
+		SAMBASICStartLine uint16
+		MGTFlags          uint8 // "MGT use only" per the Tech Manual
+		// MGTFutureAndPast occupies directory bytes 0xD2–0xDB. The
+		// Tech Manual labels these bytes unused, but SAMDOS in fact
+		// caches the file body's 9-byte FileHeader at bytes 1–9
+		// (i.e. 0xD3–0xDB) as an in-RAM scratchpad. Byte 0 (0xD2)
+		// is unused.
+		MGTFutureAndPast [10]byte
+		ReservedA        [4]byte  // spare 4 bytes at 0xE8–0xEB
+		ReservedB        [11]byte // spare 11 bytes at 0xF5–0xFF
 	}
 
-	Filename         [10]byte
+	// Filename is the 10-byte, space-padded ASCII filename stored at
+	// directory bytes 0x01–0x0A. Use String to obtain a trimmed,
+	// printable form; SAMDOS matches filenames case-insensitively.
+	Filename [10]byte
+
+	// SectorAddressMap is the 195-byte / 1560-bit allocation bitmap
+	// at directory bytes 0x0F–0xD1. Each bit corresponds to one of
+	// the disk's 1560 data sectors. Bit 0 of byte 0 is (track 4,
+	// sector 1); bits then proceed sector-then-track within side 0
+	// up to (track 79, sector 10) at bit 759, and continue with the
+	// side-1 data sectors at bit 760 onwards up to (track 207,
+	// sector 10) at bit 1559. See Sector.SAMMask for the
+	// per-sector bit-position computation.
+	//
+	// In a FileEntry, the map records the sectors that file
+	// occupies. The disk-wide free map is not stored on disk; it is
+	// computed at allocation time as the bitwise OR of every entry's
+	// map (see DiskJournal.CombinedSectorMap).
 	SectorAddressMap [195]byte
 
+	// DiskJournal is the parsed SAMDOS directory: 80 *FileEntry
+	// values in their on-disk slot order. Slot 0 is the first half
+	// of (track 0, sector 1); slot 79 is the second half of (track
+	// 3, sector 10). An unused slot has FileEntry.Used returning
+	// false (Type byte == 0).
 	DiskJournal [80]*FileEntry
 
+	// FilePart is one 510-byte payload chunk of a file body
+	// together with the (track, sector) link to the next chunk.
+	// NextSector.Track == 0 marks the last chunk of a file.
 	FilePart struct {
 		Data       [510]byte
 		NextSector *Sector
 	}
 
+	// FileHeader is the 9-byte header that prefixes every file
+	// body on disk (file body bytes 0–8). The directory entry
+	// duplicates these fields into its StartAddressPage /
+	// StartAddressPageOffset / Pages / LengthMod16K members, but
+	// the body header is what the ROM consumes when LOADing.
+	//
+	// LengthMod16K plus Pages gives the body length excluding the
+	// header (see Length); PageOffset and StartPage together
+	// encode the SAM address the file should be loaded to in REL
+	// PAGE FORM (see Start).
 	FileHeader struct {
 		Type         FileType
 		LengthMod16K uint16
@@ -57,29 +182,44 @@ type (
 		StartPage    uint8
 	}
 
+	// File is a complete file as read from disk: the 9-byte
+	// FileHeader followed by Body. Body excludes the header bytes.
 	File struct {
 		Header *FileHeader
 		Body   []byte
 	}
 
+	// Sector identifies a (Track, Sector) location on disk.
+	// Track uses SAMDOS's side-encoding (bit 7 = side bit): values
+	// 0–79 are side 0, values 128–207 are side 1; values 80–127
+	// and 208+ are invalid. Sector is 1-based and runs 1–10.
+	// Tracks 0–3 of side 0 hold the directory; tracks 4–79 and
+	// 128–207 hold file data. Use Offset to map a Sector to a
+	// byte offset within a DiskImage.
 	Sector struct {
-		// 0-79 or 128-207
-		Track uint8
-		// 1-10
-		Sector uint8
+		Track  uint8 // 0–79 (side 0) or 128–207 (side 1)
+		Sector uint8 // 1–10
 	}
 )
 
+// SAMDOS file types — values of the status / file-type byte at offset
+// 0x00 of a directory entry (and byte 0 of the file body). FT_ERASED
+// (0) is the "free slot" sentinel; the others are the public SAM
+// types defined by the Tech Manual. Bit 7 of the byte marks the file
+// HIDDEN and bit 6 marks it PROTECTED — mask them off before comparing
+// against these constants.
 const (
-	FT_ERASED      = FileType(0)
-	FT_ZX_SNAPSHOT = FileType(5)
-	FT_SAM_BASIC   = FileType(16)
-	FT_NUM_ARRAY   = FileType(17)
-	FT_STR_ARRAY   = FileType(18)
-	FT_CODE        = FileType(19)
-	FT_SCREEN      = FileType(20)
+	FT_ERASED      = FileType(0)  // slot is unused
+	FT_ZX_SNAPSHOT = FileType(5)  // 48K ZX Spectrum snapshot (SAMDOS extension)
+	FT_SAM_BASIC   = FileType(16) // tokenised SAM BASIC program; body decoded by SAMBasic.Output
+	FT_NUM_ARRAY   = FileType(17) // saved numeric array
+	FT_STR_ARRAY   = FileType(18) // saved string array
+	FT_CODE        = FileType(19) // arbitrary code/data blob with load (and optional execution) address
+	FT_SCREEN      = FileType(20) // SCREEN$ — display memory dump; mode stored at FileTypeInfo[0]
 )
 
+// Output prints a debug summary of file to stdout: type, start address,
+// body length, and the raw body bytes.
 func (file *File) Output() {
 	fmt.Printf("Type:                %v\n", file.Header.Type)
 	fmt.Printf("Start:               %v\n", file.Header.Start())
@@ -87,14 +227,22 @@ func (file *File) Output() {
 	fmt.Printf("Body:\n%v\n", file.Body)
 }
 
+// Start decodes the file's load address from the header's REL PAGE FORM
+// encoding (StartPage's low 5 bits give the 16K-page index, PageOffset's
+// low 14 bits give the offset within that page). The returned address
+// is a linear offset into SAM's 512K address space.
 func (fileHeader *FileHeader) Start() uint32 {
 	return uint32(fileHeader.PageOffset&0x3fff) | uint32((fileHeader.StartPage&0x1f)+1)<<14
 }
 
+// Length is the size in bytes of the file body, excluding the 9-byte
+// header itself. Decoded as Pages × 16384 + (LengthMod16K & 0x3FFF).
 func (fileHeader *FileHeader) Length() uint32 {
 	return uint32(fileHeader.LengthMod16K&0x3fff) | uint32(fileHeader.Pages)<<14
 }
 
+// String returns the map as a 390-character lowercase hex dump (two
+// chars per byte, no spacing).
 func (sam *SectorAddressMap) String() string {
 	out := ""
 	h := make([]byte, hex.EncodedLen(len(sam[:])))
@@ -130,20 +278,33 @@ func (sam *SectorAddressMap) filterSectors(used bool) []*Sector {
 	return sectors
 }
 
+// UsedSectors returns the Sector locations whose bits are set in sam,
+// in disk order. For a FileEntry's map this is the file's sector
+// chain; for a CombinedSectorMap it is every allocated sector on the
+// disk.
 func (sam *SectorAddressMap) UsedSectors() []*Sector {
 	return sam.filterSectors(true)
 }
 
+// FreeSectors returns the Sector locations whose bits are clear in
+// sam, in disk order. Most useful on a CombinedSectorMap, where it
+// enumerates the disk's available data sectors.
 func (sam *SectorAddressMap) FreeSectors() []*Sector {
 	return sam.filterSectors(false)
 }
 
+// Merge sets in sam every bit that is set in s (bitwise OR, in place).
+// Used to accumulate per-file maps into the disk-wide allocation map
+// (see DiskJournal.CombinedSectorMap).
 func (sam *SectorAddressMap) Merge(s *SectorAddressMap) {
 	for i := range sam {
 		sam[i] = sam[i] | s[i]
 	}
 }
 
+// String returns the file type's mnemonic ("Code", "SAM BASIC",
+// "Screen", etc.). Values outside the documented FT_* set render as
+// "UNKNOWN (n)".
 func (ft FileType) String() string {
 	switch ft {
 	case FT_ERASED:
@@ -165,6 +326,8 @@ func (ft FileType) String() string {
 	}
 }
 
+// String formats sector as "Track N / Sector M" with the raw
+// side-encoded Track value (so side-1 locations show as 128–207).
 func (sector *Sector) String() string {
 	return fmt.Sprintf("Track %v / Sector %v", sector.Track, sector.Sector)
 }
@@ -176,6 +339,11 @@ func (sector *Sector) String() string {
 // Reference: https://www.cpcwiki.eu/index.php/Format:DSK_disk_image_file_format
 var edskMagic = []byte("EXTENDED CPC DSK File")
 
+// Load reads filename as a raw MGT disk image. Files smaller than
+// 819200 bytes are zero-padded on the right; files larger than that
+// are truncated. Extended CPC DSK images ("EDSK" — magic bytes
+// "EXTENDED CPC DSK File") are detected and rejected with a message
+// pointing at samdisk, which can convert them to MGT.
 func Load(filename string) (*DiskImage, error) {
 	image, err := os.ReadFile(filename)
 	if err != nil {
@@ -189,6 +357,9 @@ func Load(filename string) (*DiskImage, error) {
 	return &d, nil
 }
 
+// Save writes the whole 819200-byte image to filename, with mode 0400
+// (read-only for the owner). The destination is overwritten if it
+// already exists.
 func (di *DiskImage) Save(filename string) error {
 	err := os.WriteFile(filename, di[:], 0400)
 	if err != nil {
@@ -197,6 +368,9 @@ func (di *DiskImage) Save(filename string) error {
 	return nil
 }
 
+// SectorData returns a copy of the 512 bytes at sector's location.
+// Returns an error if sector.Sector is outside 1–10 or sector.Track
+// falls in the invalid gap 80–127 or above 207.
 func (i *DiskImage) SectorData(sector *Sector) (*SectorData, error) {
 	if sector.Sector < 1 || sector.Sector > 10 {
 		debug.PrintStack()
@@ -211,6 +385,10 @@ func (i *DiskImage) SectorData(sector *Sector) (*SectorData, error) {
 	return &data, nil
 }
 
+// FilePart reinterprets data as one chunk of a file's sector chain:
+// the first 510 bytes become the payload and the trailing 2 bytes
+// become the (track, sector) link to the next chunk. A returned
+// NextSector with Track == 0 marks end-of-file.
 func (data *SectorData) FilePart() *FilePart {
 	fp := FilePart{
 		NextSector: &Sector{
@@ -222,6 +400,12 @@ func (data *SectorData) FilePart() *FilePart {
 	return &fp
 }
 
+// DiskJournal parses the 80-slot SAMDOS directory from tracks 0–3 of
+// side 0. Slots are returned in on-disk order, with each
+// FileEntry's fields populated from its 256 directory bytes; use
+// FileEntry.Used to tell occupied slots from free ones. The returned
+// directory is a snapshot — mutating it does not change the
+// underlying image until WriteFileEntry is called.
 func (i *DiskImage) DiskJournal() *DiskJournal {
 	dl := DiskJournal{}
 	index := 0
@@ -248,6 +432,27 @@ func (i *DiskImage) DiskJournal() *DiskJournal {
 	return &dl
 }
 
+// FileEntryFrom parses the 256 bytes of a single SAMDOS directory
+// slot into a FileEntry. The on-disk byte map is:
+//
+//	0x00      Type / status byte
+//	0x01–0x0A Filename (10 bytes, space-padded)
+//	0x0B–0x0C Sector count (big-endian!)
+//	0x0D–0x0E First-sector track and sector
+//	0x0F–0xD1 SectorAddressMap (195 bytes)
+//	0xD2–0xDB MGTFutureAndPast (SAMDOS scratchpad — see FileEntry doc)
+//	0xDC      MGTFlags
+//	0xDD–0xE7 FileTypeInfo (11 bytes, type-dependent)
+//	0xE8–0xEB ReservedA
+//	0xEC      StartAddressPage
+//	0xED–0xEE StartAddressPageOffset (little-endian)
+//	0xEF      Pages
+//	0xF0–0xF1 LengthMod16K (little-endian)
+//	0xF2      ExecutionAddressDiv16K
+//	0xF3–0xF4 ExecutionAddressMod16K / SAMBASICStartLine (little-endian)
+//	0xF5–0xFF ReservedB
+//
+// Inverse of FileEntry.Raw.
 func FileEntryFrom(data [0x100]byte) *FileEntry {
 	fe := FileEntry{
 		Type:    FileType(data[0x00]),
@@ -276,6 +481,8 @@ func FileEntryFrom(data [0x100]byte) *FileEntry {
 	return &fe
 }
 
+// Raw encodes fe back into the 256 raw bytes of a SAMDOS directory
+// entry. Inverse of FileEntryFrom.
 func (fe *FileEntry) Raw() [0x100]byte {
 	raw := [0x100]byte{}
 	raw[0x00] = byte(fe.Type)
@@ -320,6 +527,9 @@ func (fe *FileEntry) Raw() [0x100]byte {
 	return raw
 }
 
+// Output prints a per-file summary of every occupied directory slot
+// to stdout — the format used by the `samfile ls` command. Per-entry
+// errors are logged but do not stop the walk.
 func (dj *DiskJournal) Output() {
 	for _, fe := range dj {
 		err := fe.Output()
@@ -329,6 +539,12 @@ func (dj *DiskJournal) Output() {
 	}
 }
 
+// CombinedSectorMap returns the bitwise OR of every entry's
+// SectorAddressMap. The result is the disk-wide allocation bitmap:
+// a set bit means "some file owns this sector", a clear bit means
+// "this sector is free". SAMDOS doesn't persist this bitmap on disk;
+// it reconstructs it on demand at allocation time, and so does
+// samfile (see AddCodeFile).
 func (dj *DiskJournal) CombinedSectorMap() *SectorAddressMap {
 	sam := new(SectorAddressMap)
 	for _, fe := range dj {
@@ -347,14 +563,23 @@ func (dj *DiskJournal) filterFileEntries(used bool) []int {
 	return entries
 }
 
+// UsedFileEntries returns the slot indices (0–79) whose entries are
+// occupied (FileEntry.Used == true).
 func (dj *DiskJournal) UsedFileEntries() []int {
 	return dj.filterFileEntries(true)
 }
 
+// FreeFileEntries returns the slot indices (0–79) that are available
+// for new files. AddCodeFile populates the lowest free slot.
 func (dj *DiskJournal) FreeFileEntries() []int {
 	return dj.filterFileEntries(false)
 }
 
+// Used reports whether the directory slot is occupied. SAMDOS itself
+// only treats slots with Type == 0 as erased; samfile additionally
+// rejects slots whose Type byte is not one of the documented FT_*
+// values or whose FirstSector.Track is 0 (the directory tracks, which
+// can never be a file's first sector).
 func (fe *FileEntry) Used() bool {
 	if strings.HasPrefix(fe.Type.String(), "UNKNOWN") {
 		return false
@@ -365,6 +590,10 @@ func (fe *FileEntry) Used() bool {
 	return true
 }
 
+// Output prints a per-field human-readable summary of fe to stdout
+// (the per-entry block of `samfile ls` output). Unused slots are
+// silently skipped. Returns an error if FirstSector.Track is in the
+// directory area (0–3, which is structurally invalid for a file).
 func (fe *FileEntry) Output() error {
 	if !fe.Used() {
 		return nil
@@ -425,45 +654,66 @@ func pageFormLength(b0, b1, b2 byte) uint32 {
 // ROM disasm L16005-16012 ("CDE=LEN OF PROG ALONE" / "CDE=LEN OF
 // PROG+NVARS+GAP").
 
-// ProgramLength is the size in bytes of the SAM BASIC program text,
-// excluding any variables.
+// ProgramLength is the size in bytes of the tokenised SAM BASIC
+// program text, excluding the trailing numeric-variables / gap /
+// string-array sections. Only meaningful for FT_SAM_BASIC entries.
 func (fe *FileEntry) ProgramLength() uint32 {
 	return pageFormLength(fe.FileTypeInfo[0], fe.FileTypeInfo[1], fe.FileTypeInfo[2])
 }
 
-// NumericVariablesSize is the size in bytes of the numeric variables
-// section that immediately follows the program text.
+// NumericVariablesSize is the size in bytes of the numeric-variables
+// section that immediately follows the program text in a saved SAM
+// BASIC file. Only meaningful for FT_SAM_BASIC entries.
 func (fe *FileEntry) NumericVariablesSize() uint32 {
 	return pageFormLength(fe.FileTypeInfo[3], fe.FileTypeInfo[4], fe.FileTypeInfo[5]) -
 		pageFormLength(fe.FileTypeInfo[0], fe.FileTypeInfo[1], fe.FileTypeInfo[2])
 }
 
-// GapSize is the size in bytes of the gap that SAM BASIC leaves between
-// the numeric variables and the string/array variables.
+// GapSize is the size in bytes of the empty gap SAM BASIC leaves
+// between the numeric variables and the string/array variables. On
+// canonical SAVEs this is usually 512 (the ROM's MAKEROOM
+// pre-allocation). Only meaningful for FT_SAM_BASIC entries.
 func (fe *FileEntry) GapSize() uint32 {
 	return pageFormLength(fe.FileTypeInfo[6], fe.FileTypeInfo[7], fe.FileTypeInfo[8]) -
 		pageFormLength(fe.FileTypeInfo[3], fe.FileTypeInfo[4], fe.FileTypeInfo[5])
 }
 
-// StringArrayVariablesSize is the size in bytes of the string and array
-// variables section, which occupies the remainder of the file after the
-// gap.
+// StringArrayVariablesSize is the size in bytes of the string and
+// array variables section, which occupies the remainder of the body
+// after the gap. Only meaningful for FT_SAM_BASIC entries.
 func (fe *FileEntry) StringArrayVariablesSize() uint32 {
 	return fe.Length() - pageFormLength(fe.FileTypeInfo[6], fe.FileTypeInfo[7], fe.FileTypeInfo[8])
 }
 
+// ExecutionAddress decodes the auto-execution address of an FT_CODE
+// entry from its REL PAGE FORM encoding. The caller should first
+// check that ExecutionAddressDiv16K is not 0xFF (the sentinel for
+// "no auto-execution address set").
 func (fe *FileEntry) ExecutionAddress() uint32 {
 	return uint32(fe.ExecutionAddressMod16K&0x3fff) | uint32(fe.ExecutionAddressDiv16K&0x1f)<<14
 }
 
+// StartAddress decodes the linear SAM address the file body should
+// be loaded to, from the REL PAGE FORM encoding mirrored from the
+// FileHeader. Equivalent to calling Start on the corresponding
+// FileHeader.
 func (fe *FileEntry) StartAddress() uint32 {
 	return uint32(fe.StartAddressPageOffset&0x3fff) | uint32((fe.StartAddressPage&0x1f)+1)<<14
 }
 
+// Length is the size in bytes of the file body, excluding the 9-byte
+// header. Decoded as Pages × 16384 + (LengthMod16K & 0x3FFF) —
+// equivalent to FileHeader.Length on the same file.
 func (fe *FileEntry) Length() uint32 {
 	return uint32(fe.LengthMod16K&0x3fff) | uint32(fe.Pages)<<14
 }
 
+// File reads the named file out of the disk image, walking its
+// sector chain from FirstSector and assembling the body. The match
+// against filename is exact against the trimmed Filename.String() of
+// each occupied directory entry — there is no wildcard or
+// case-folding. The returned File.Header is reconstructed from the
+// first 9 bytes of the body; File.Body is the remainder.
 func (di *DiskImage) File(filename string) (*File, error) {
 
 	for _, fe := range di.DiskJournal() {
@@ -504,6 +754,8 @@ func (di *DiskImage) File(filename string) (*File, error) {
 	return nil, fmt.Errorf("file %v not found", filename)
 }
 
+// String returns filename with any trailing NULs and spaces removed,
+// suitable for matching against user input.
 func (filename Filename) String() string {
 	b := make([]byte, 0, 10)
 	for _, k := range filename {
@@ -515,6 +767,18 @@ func (filename Filename) String() string {
 	return strings.TrimRight(string(b), " ")
 }
 
+// AddCodeFile writes data to the disk image as a new SAMDOS type-19
+// (CODE) file named name, allocating a free directory slot and the
+// required free sectors. loadAddress is the SAM address the file
+// will be loaded to (must be ≥ 0x4000 — anything below is in ROM —
+// and the file must fit within SAM's 512K address space).
+// executionAddress is optional: 0 records "no auto-exec", any other
+// value is the address the loader will JP to after loading and must
+// lie within the loaded region.
+//
+// Returns an error if the address validations fail, if the disk has
+// no free directory slots (max 80 files), or if there are not enough
+// free sectors to hold the data plus the 9-byte file header.
 func (di *DiskImage) AddCodeFile(name string, data []byte, loadAddress, executionAddress uint32) error {
 	if loadAddress < 1<<14 {
 		return fmt.Errorf("load address %v of %q is in ROM but must be %v of higher to be loaded into RAM", loadAddress, name, 1<<14)
@@ -546,6 +810,10 @@ func (di *DiskImage) AddCodeFile(name string, data []byte, loadAddress, executio
 	)
 }
 
+// CreateHeader synthesises the 9-byte FileHeader that should prefix
+// the file body, by copying the directory entry's mirrored
+// metadata fields (Type, length, start-page/offset). Used by
+// addFile to construct the on-disk header for a new file.
 func (fe *FileEntry) CreateHeader() *FileHeader {
 	return &FileHeader{
 		Type:         fe.Type,
@@ -599,6 +867,9 @@ func (di *DiskImage) addFile(name string, fe *FileEntry, data []byte) error {
 	return nil
 }
 
+// WriteFileEntry encodes dj[index] back into the 256 bytes of
+// directory slot index. Call this after mutating an entry to commit
+// the change to the disk image. No bounds checking on index.
 func (di *DiskImage) WriteFileEntry(dj *DiskJournal, index int) {
 	offset := index << 8
 	rawFileEntry := dj[index].Raw()
@@ -607,15 +878,28 @@ func (di *DiskImage) WriteFileEntry(dj *DiskJournal, index int) {
 	}
 }
 
+// SAMMask returns the (byte offset, bit mask) within a
+// 195-byte SectorAddressMap that corresponds to sector. The bit
+// position is computed as ((Track & 0x7f) × 10) + (Sector − 1) +
+// (sideBit × 800) − 40 — the −40 accounts for the directory tracks
+// being outside the map's domain. Used by AddCodeFile to update the
+// per-file map.
 func (sector *Sector) SAMMask() (offset uint8, mask uint8) {
 	bitOffset := (int(sector.Track)&0x7f)*10 + int(sector.Sector) - 1 + ((int(sector.Track)&0x80)>>7)*800 - 40
 	return uint8(bitOffset >> 3), 1 << (bitOffset & 0x07)
 }
 
+// Offset returns the byte offset into a DiskImage at which sector's
+// 512 bytes begin. The MGT layout is cylinder-interleaved: within
+// each 10240-byte cylinder, side 0's 5120 bytes precede side 1's
+// 5120 bytes.
 func (sector *Sector) Offset() int {
 	return int(sector.Track>>7)*5120 + (int(sector.Sector)-1)*512 + int(sector.Track&0x7f)*10240
 }
 
+// WriteSector copies sd's 512 bytes into the disk image at sector's
+// location. Unlike SectorData, this performs no validation — a
+// malformed Sector silently corrupts the image.
 func (di *DiskImage) WriteSector(sector *Sector, sd *SectorData) {
 	offset := sector.Offset()
 	for i, b := range sd {
@@ -623,6 +907,10 @@ func (di *DiskImage) WriteSector(sector *Sector, sd *SectorData) {
 	}
 }
 
+// Raw encodes fh into its 9-byte on-disk form (the bytes that
+// prefix the file body). Bytes 5–6 are emitted as 0x00,0x00; a
+// real ROM SAVE writes 0xFF,0xFF there, but both are spec-compliant
+// ("unused" per the Tech Manual).
 func (fh *FileHeader) Raw() [9]byte {
 	return [9]byte{
 		byte(fh.Type),
@@ -637,6 +925,8 @@ func (fh *FileHeader) Raw() [9]byte {
 	}
 }
 
+// Raw returns the bytes that go to disk: the 9-byte FileHeader
+// followed by the body.
 func (file *File) Raw() []byte {
 	h := file.Header.Raw()
 	return append(h[:], file.Body...)


### PR DESCRIPTION
## Summary
- Replaces the one-line package comment with a package overview covering MGT disk layout (geometry, side encoding, directory vs data area, sector chains) and the API model
- Adds doc comments to every exported type, constant, function and method, plus selective field-level comments on `FileEntry` where names alone are ambiguous (`FileTypeInfo`, the body-header mirror fields, `ExecutionAddress*`, `SAMBASICStartLine`, `MGTFutureAndPast`)
- Documents the SAMBasic wire format (line/keyword/numeric-literal encoding) and the unexported `keywords` table
- Adds a one-paragraph command doc to `cmd/samfile` so pkg.go.dev shows a useful summary for the binary alongside the library

No behaviour changes; pure docs.

## Test plan
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [x] `go test ./...` passes
- [x] `go test -race ./...` passes (matches CI)
- [x] Rendered locally via `pkgsite` and reviewed
- [ ] CI checks green

🤖 Generated with [Claude Code](https://claude.com/claude-code)