### PR TITLE
feat: three small completeness fixes around file headers

### DIFF
--- a/samfile.go
+++ b/samfile.go
@@ -176,12 +176,24 @@ type (
 	// header (see Length); PageOffset and StartPage together
 	// encode the SAM address the file should be loaded to in REL
 	// PAGE FORM (see Start).
+	//
+	// ExecutionAddressDiv16K and ExecutionAddressMod16KLo mirror
+	// the directory entry's auto-execution-address gate at body-
+	// header bytes 5 and 6. Setting both to 0xFF signals "no
+	// auto-exec" — the convention the SAM ROM's LOAD-CODE path
+	// at rom-disasm:22471-22484 checks to return cleanly after a
+	// load instead of jumping to the file's start address. The
+	// directory entry holds the full 16-bit ExecutionAddressMod16K
+	// at offsets 0xF3-0xF4; only the low byte fits in the body
+	// header, which is what these fields represent.
 	FileHeader struct {
-		Type         FileType
-		LengthMod16K uint16
-		PageOffset   uint16
-		Pages        uint8
-		StartPage    uint8
+		Type                   FileType
+		LengthMod16K           uint16
+		PageOffset             uint16
+		ExecutionAddressDiv16K uint8
+		ExecutionAddressMod16KLo uint8
+		Pages                  uint8
+		StartPage              uint8
 	}
 
 	// File is a complete file as read from disk: the 9-byte
@@ -742,11 +754,13 @@ func (di *DiskImage) File(filename string) (*File, error) {
 			}
 			file := &File{
 				Header: &FileHeader{
-					Type:         FileType(raw[0]),
-					LengthMod16K: uint16(raw[1]) | uint16(raw[2])<<8,
-					PageOffset:   uint16(raw[3]) | uint16(raw[4])<<8,
-					Pages:        raw[7],
-					StartPage:    raw[8] & 0x1f,
+					Type:                     FileType(raw[0]),
+					LengthMod16K:             uint16(raw[1]) | uint16(raw[2])<<8,
+					PageOffset:               uint16(raw[3]) | uint16(raw[4])<<8,
+					ExecutionAddressDiv16K:   raw[5],
+					ExecutionAddressMod16KLo: raw[6],
+					Pages:                    raw[7],
+					StartPage:                raw[8] & 0x1f,
 				},
 				Body: raw[9:],
 			}
@@ -816,6 +830,32 @@ func NewDiskImage() *DiskImage {
 	return &DiskImage{}
 }
 
+// SetStartAddressPageRaw overwrites the StartAddressPage byte for the
+// named file in both the directory entry (raw[0xEC]) and the matching
+// body-header byte 8 in the file's first sector. Returns an error if
+// the file is not present on disk.
+//
+// AddCodeFile derives StartAddressPage from the load address (low 5
+// bits = physical page index); the high 3 bits are decorative — ROM
+// masks them off when reading. Use this method when byte-perfect
+// parity with the canonical SAM SAVE convention matters: real-SAVE
+// output on FRED 02 / Defender disks records samdos2's StartAddress-
+// Page as 0x7D (0x60 decorative bits + 0x1D page index), whereas
+// AddCodeFile with load address 491529 derives 0x1D alone.
+func (di *DiskImage) SetStartAddressPageRaw(name string, value byte) error {
+	dj := di.DiskJournal()
+	for slot, fe := range dj {
+		if !fe.Used() || fe.Name.String() != name {
+			continue
+		}
+		fe.StartAddressPage = value
+		di.WriteFileEntry(dj, slot)
+		di[fe.FirstSector.Offset()+8] = value
+		return nil
+	}
+	return fmt.Errorf("file %v not found", name)
+}
+
 func pageForm3Byte(value uint32) [3]byte {
 	page := byte(value / 16384)
 	offset := uint16(value%16384) | 0x8000
@@ -849,18 +889,8 @@ func (di *DiskImage) AddBasicFile(name string, file *sambasic.File) error {
 	copy(fe.FileTypeInfo[3:6], numend[:])
 	copy(fe.FileTypeInfo[6:9], savars[:])
 
-	pages := uint8(len(body) >> 14)
-	lengthMod16K := uint16(len(body) & 0x3FFF)
-	fe.MGTFutureAndPast[1] = byte(FT_SAM_BASIC)
-	fe.MGTFutureAndPast[2] = byte(lengthMod16K)
-	fe.MGTFutureAndPast[3] = byte(lengthMod16K >> 8)
-	fe.MGTFutureAndPast[4] = 0xD5 // PageOffset lo
-	fe.MGTFutureAndPast[5] = 0x9C // PageOffset hi
-	fe.MGTFutureAndPast[6] = 0xFF
-	fe.MGTFutureAndPast[7] = 0xFF
-	fe.MGTFutureAndPast[8] = pages
-	fe.MGTFutureAndPast[9] = 0x00
-
+	// addFile sets fe.Pages, fe.LengthMod16K, and mirrors the body
+	// header into MGTFutureAndPast — no need to populate either here.
 	return di.addFile(name, fe, body)
 }
 
@@ -870,11 +900,13 @@ func (di *DiskImage) AddBasicFile(name string, file *sambasic.File) error {
 // addFile to construct the on-disk header for a new file.
 func (fe *FileEntry) CreateHeader() *FileHeader {
 	return &FileHeader{
-		Type:         fe.Type,
-		LengthMod16K: fe.LengthMod16K,
-		PageOffset:   fe.StartAddressPageOffset,
-		Pages:        fe.Pages,
-		StartPage:    fe.StartAddressPage,
+		Type:                     fe.Type,
+		LengthMod16K:             fe.LengthMod16K,
+		PageOffset:               fe.StartAddressPageOffset,
+		ExecutionAddressDiv16K:   fe.ExecutionAddressDiv16K,
+		ExecutionAddressMod16KLo: byte(fe.ExecutionAddressMod16K & 0xff),
+		Pages:                    fe.Pages,
+		StartPage:                fe.StartAddressPage,
 	}
 }
 
@@ -901,6 +933,17 @@ func (di *DiskImage) addFile(name string, fe *FileEntry, data []byte) error {
 		Body:   data,
 	}
 	raw := f.Raw()
+
+	// Mirror the 9-byte body header into MGTFutureAndPast[1..9] so
+	// the directory entry's MGT "future and past" region matches the
+	// canonical real-SAVE convention: every byte of the body header
+	// is duplicated in the dir entry. (MGTFutureAndPast[0] is
+	// reserved and stays zero.) Without this mirror an inspector
+	// reading just the dir entry would see all zeros for the body
+	// header bytes that are otherwise authoritatively held there;
+	// real disks saved by ROM SAVE populate this region.
+	header := f.Header.Raw()
+	copy(fe.MGTFutureAndPast[1:10], header[:])
 
 	sd := &SectorData{}
 	for i := 0; i < requiredSectorCount; i++ {
@@ -972,8 +1015,8 @@ func (fh *FileHeader) Raw() [9]byte {
 		byte(fh.LengthMod16K >> 8),
 		byte(fh.PageOffset),
 		byte(fh.PageOffset >> 8),
-		0,
-		0,
+		fh.ExecutionAddressDiv16K,
+		fh.ExecutionAddressMod16KLo,
 		fh.Pages,
 		fh.StartPage,
 	}

--- a/samfile.go
+++ b/samfile.go
@@ -830,24 +830,38 @@ func NewDiskImage() *DiskImage {
 	return &DiskImage{}
 }
 
-// SetStartAddressPageRaw overwrites the StartAddressPage byte for the
-// named file in both the directory entry (raw[0xEC]) and the matching
-// body-header byte 8 in the file's first sector. Returns an error if
-// the file is not present on disk.
+// SetStartAddressPageUnusedBits sets the upper 3 bits (bits 7..5) of
+// the StartAddressPage byte for the named file, preserving the low 5
+// bits (the physical page index). The change is applied to both the
+// directory entry (raw[0xEC]) and the matching body-header byte 8 in
+// the file's first sector. Returns an error if bits > 7 or if the
+// file is not present on disk.
 //
-// AddCodeFile derives StartAddressPage from the load address (low 5
-// bits = physical page index); the high 3 bits are decorative — ROM
-// masks them off when reading. Use this method when byte-perfect
-// parity with the canonical SAM SAVE convention matters: real-SAVE
-// output on FRED 02 / Defender disks records samdos2's StartAddress-
-// Page as 0x7D (0x60 decorative bits + 0x1D page index), whereas
-// AddCodeFile with load address 491529 derives 0x1D alone.
-func (di *DiskImage) SetStartAddressPageRaw(name string, value byte) error {
+// The low 5 bits of StartAddressPage are the page index (0–31) and
+// are derived by AddCodeFile from the load address — this method
+// intentionally cannot disturb them. The high 3 bits are unused: no
+// known consumer in SAM ROM v3, SAMDOS 2, or MasterDOS reads them
+// (ROM's TSURPG paging routine XORs them away via the
+// `XOR / AND 0xE0 / XOR` idiom at rom-disasm:14852-14859; SAMDOS's
+// hsave masks with `AND 0x1F` at h.s:140-143). Real-SAVE output on
+// FRED 02 / Defender disks nonetheless records samdos2's
+// StartAddressPage as 0x7D (= 3<<5 | 0x1D = page 29 with the top
+// two bits set) — those bits are an unmasked leak of the HMPR
+// video-mode flags at the moment SAM ROM's BASIC SAVE wrote the
+// byte (see rom-disasm:22866-22869). This method exists to
+// reproduce that historical accident byte-for-byte when comparing
+// against canonical reference images; if you don't have that
+// constraint, you don't need to call this.
+func (di *DiskImage) SetStartAddressPageUnusedBits(name string, bits uint8) error {
+	if bits > 7 {
+		return fmt.Errorf("StartAddressPage unused bits value %d out of range (0..7)", bits)
+	}
 	dj := di.DiskJournal()
 	for slot, fe := range dj {
 		if !fe.Used() || fe.Name.String() != name {
 			continue
 		}
+		value := (fe.StartAddressPage & 0x1F) | (bits << 5)
 		fe.StartAddressPage = value
 		di.WriteFileEntry(dj, slot)
 		di[fe.FirstSector.Offset()+8] = value

--- a/samfile_test.go
+++ b/samfile_test.go
@@ -818,3 +818,210 @@ func TestMultiFileBasicAndCode(t *testing.T) {
 		}
 	}
 }
+
+// firstSectorBytes returns the first sector's payload for the named
+// file. Convenience wrapper for body-header assertions: AddCodeFile
+// writes the 9-byte FileHeader at body bytes 0..8 = first-sector
+// bytes 0..8, so callers can index directly.
+func firstSectorBytes(t *testing.T, di *DiskImage, name string) [512]byte {
+	t.Helper()
+	for _, fe := range di.DiskJournal() {
+		if fe.Used() && fe.Name.String() == name {
+			sd, err := di.SectorData(fe.FirstSector)
+			if err != nil {
+				t.Fatalf("SectorData(%v): %v", fe.FirstSector, err)
+			}
+			return [512]byte(*sd)
+		}
+	}
+	t.Fatalf("file %q not present on disk", name)
+	return [512]byte{}
+}
+
+func usedFileEntry(t *testing.T, di *DiskImage, name string) *FileEntry {
+	t.Helper()
+	for _, fe := range di.DiskJournal() {
+		if fe.Used() && fe.Name.String() == name {
+			return fe
+		}
+	}
+	t.Fatalf("file %q not present on disk", name)
+	return nil
+}
+
+// TestFileHeaderRawEmitsExecutionAddress pins down the body-header
+// bytes 5-6 encoding. The previous implementation hard-coded these
+// to 0x00 0x00, which broke ROM's LOAD-CODE auto-exec gate at
+// rom-disasm:22471-22484: a CODE file loaded via `LOAD ... CODE addr`
+// is auto-executed unless BOTH dir byte 0xF2 AND body-header byte 6
+// are 0xFF. Without this fix, a no-auto-exec file emitted by
+// AddCodeFile would mis-fire its post-load auto-exec on real SAM.
+func TestFileHeaderRawEmitsExecutionAddress(t *testing.T) {
+	cases := []struct {
+		name             string
+		execDiv16K       byte
+		execMod16KLo     byte
+		wantByte5        byte
+		wantByte6        byte
+	}{
+		{"no auto-exec (sentinel 0xff 0xff)", 0xFF, 0xFF, 0xFF, 0xFF},
+		{"auto-exec at 0x4000 (page 0, offset 0)", 0x00, 0x00, 0x00, 0x00},
+		{"auto-exec at 0x9039 (page 1, low byte 0x39)", 0x01, 0x39, 0x01, 0x39},
+		{"auto-exec at 0xC000 (page 2, low byte 0x00)", 0x02, 0x00, 0x02, 0x00},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fh := &FileHeader{
+				Type:                     FT_CODE,
+				LengthMod16K:             100,
+				PageOffset:               0x8000,
+				ExecutionAddressDiv16K:   c.execDiv16K,
+				ExecutionAddressMod16KLo: c.execMod16KLo,
+				Pages:                    0,
+				StartPage:                1,
+			}
+			raw := fh.Raw()
+			if raw[5] != c.wantByte5 {
+				t.Errorf("raw[5] = 0x%02x; want 0x%02x", raw[5], c.wantByte5)
+			}
+			if raw[6] != c.wantByte6 {
+				t.Errorf("raw[6] = 0x%02x; want 0x%02x", raw[6], c.wantByte6)
+			}
+		})
+	}
+}
+
+// TestAddCodeFileBodyHeaderAutoExecGate is the user-facing check for
+// the auto-exec gate: AddCodeFile with executionAddress=0 must produce
+// a body header whose bytes 5-6 are both 0xFF, so ROM's LOAD-CODE
+// path returns cleanly to BASIC after a load.
+func TestAddCodeFileBodyHeaderAutoExecGate(t *testing.T) {
+	di := NewDiskImage()
+	if err := di.AddCodeFile("F", []byte("test"), 0x8000, 0); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+	first := firstSectorBytes(t, di, "F")
+	if first[5] != 0xFF || first[6] != 0xFF {
+		t.Errorf("body header bytes 5-6 = 0x%02x 0x%02x; want 0xFF 0xFF (no auto-exec)", first[5], first[6])
+	}
+}
+
+// TestAddCodeFileBodyHeaderExecAddrMirror pairs with the auto-exec
+// gate test above: when executionAddress IS set, the body header
+// must mirror ExecutionAddressDiv16K at byte 5 and ExecutionAddress-
+// Mod16K's low byte at byte 6 (the high byte doesn't fit in the
+// 9-byte body header — the dir entry's 0xF3-0xF4 are authoritative).
+func TestAddCodeFileBodyHeaderExecAddrMirror(t *testing.T) {
+	di := NewDiskImage()
+	if err := di.AddCodeFile("F", make([]byte, 1024), 0x8000, 0x8200); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+	fe := usedFileEntry(t, di, "F")
+	first := firstSectorBytes(t, di, "F")
+	if first[5] != fe.ExecutionAddressDiv16K {
+		t.Errorf("body header byte 5 = 0x%02x; want 0x%02x (fe.ExecutionAddressDiv16K)", first[5], fe.ExecutionAddressDiv16K)
+	}
+	if first[6] != byte(fe.ExecutionAddressMod16K&0xFF) {
+		t.Errorf("body header byte 6 = 0x%02x; want 0x%02x (fe.ExecutionAddressMod16K low)", first[6], fe.ExecutionAddressMod16K&0xFF)
+	}
+}
+
+// TestAddCodeFileMirrorsMGTFutureAndPast verifies that addFile mirrors
+// the 9-byte body header into the directory entry's MGTFutureAndPast
+// field at offsets 1..9. Real disks saved by ROM SAVE always carry
+// this mirror; previously AddCodeFile left the region zeroed and only
+// AddBasicFile populated it.
+func TestAddCodeFileMirrorsMGTFutureAndPast(t *testing.T) {
+	di := NewDiskImage()
+	if err := di.AddCodeFile("F", []byte("hello world"), 0x8000, 0); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+	fe := usedFileEntry(t, di, "F")
+	first := firstSectorBytes(t, di, "F")
+	for i := 0; i < 9; i++ {
+		if fe.MGTFutureAndPast[i+1] != first[i] {
+			t.Errorf("MGTFutureAndPast[%d] = 0x%02x; want 0x%02x (body header byte %d)",
+				i+1, fe.MGTFutureAndPast[i+1], first[i], i)
+		}
+	}
+	if fe.MGTFutureAndPast[0] != 0x00 {
+		t.Errorf("MGTFutureAndPast[0] = 0x%02x; want 0x00 (reserved)", fe.MGTFutureAndPast[0])
+	}
+}
+
+// TestAddBasicFileStillMirrorsMGTFutureAndPast guards against a
+// regression where the AddBasicFile path stopped populating
+// MGTFutureAndPast after the addFile-level mirror was added: the
+// mirror covers both code paths, so AddBasicFile output should still
+// carry the body-header mirror in the dir entry.
+func TestAddBasicFileStillMirrorsMGTFutureAndPast(t *testing.T) {
+	di := NewDiskImage()
+	bf := &sambasic.File{
+		Lines:     []sambasic.Line{{Number: 10, Tokens: []sambasic.Token{sambasic.PRINT, sambasic.String("hi")}}},
+		StartLine: 10,
+	}
+	if err := di.AddBasicFile("auto", bf); err != nil {
+		t.Fatalf("AddBasicFile: %v", err)
+	}
+	fe := usedFileEntry(t, di, "auto")
+	first := firstSectorBytes(t, di, "auto")
+	for i := 0; i < 9; i++ {
+		if fe.MGTFutureAndPast[i+1] != first[i] {
+			t.Errorf("MGTFutureAndPast[%d] = 0x%02x; want 0x%02x (body header byte %d)",
+				i+1, fe.MGTFutureAndPast[i+1], first[i], i)
+		}
+	}
+}
+
+// TestSetStartAddressPageRaw verifies the override mechanism for
+// canonical-SAVE byte parity: SetStartAddressPageRaw must update both
+// the directory entry's StartAddressPage byte (raw[0xEC]) and the
+// matching body-header byte 8.
+//
+// The canonical FRED 02 / Defender samdos2 install records 0x7D
+// there (0x60 decorative bits + 0x1D = page 29); AddCodeFile with
+// the same load address derives 0x1D alone. ROM masks the high bits
+// off when reading, so this is byte-parity rather than functional.
+func TestSetStartAddressPageRaw(t *testing.T) {
+	di := NewDiskImage()
+	const loadAddress = uint32(491529) // page 29 + offset 9
+	if err := di.AddCodeFile("samdos2", make([]byte, 10000), loadAddress, 0); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+
+	feBefore := usedFileEntry(t, di, "samdos2")
+	if feBefore.StartAddressPage != 0x1D {
+		t.Fatalf("StartAddressPage before patch = 0x%02x; want 0x1D (derived from load 491529)", feBefore.StartAddressPage)
+	}
+
+	if err := di.SetStartAddressPageRaw("samdos2", 0x7D); err != nil {
+		t.Fatalf("SetStartAddressPageRaw: %v", err)
+	}
+
+	feAfter := usedFileEntry(t, di, "samdos2")
+	if feAfter.StartAddressPage != 0x7D {
+		t.Errorf("dir entry StartAddressPage after patch = 0x%02x; want 0x7D", feAfter.StartAddressPage)
+	}
+	first := firstSectorBytes(t, di, "samdos2")
+	if first[8] != 0x7D {
+		t.Errorf("body header byte 8 after patch = 0x%02x; want 0x7D", first[8])
+	}
+	// ROM masks to 0x1F, so the decoded Start should be unchanged.
+	if got, want := feAfter.StartAddress(), loadAddress; got != want {
+		t.Errorf("decoded Start after patch = %d; want %d (decorative bits must not affect the address)", got, want)
+	}
+}
+
+// TestSetStartAddressPageRawMissingFile confirms the helper errors
+// cleanly when the named file isn't on disk.
+func TestSetStartAddressPageRawMissingFile(t *testing.T) {
+	di := NewDiskImage()
+	err := di.SetStartAddressPageRaw("nope", 0x7D)
+	if err == nil {
+		t.Fatal("SetStartAddressPageRaw returned nil error for missing file")
+	}
+	if !strings.Contains(err.Error(), "nope") {
+		t.Errorf("error message = %q; want it to mention the missing filename", err.Error())
+	}
+}
+

--- a/samfile_test.go
+++ b/samfile_test.go
@@ -973,52 +973,79 @@ func TestAddBasicFileStillMirrorsMGTFutureAndPast(t *testing.T) {
 	}
 }
 
-// TestSetStartAddressPageRaw verifies the override mechanism for
-// canonical-SAVE byte parity: SetStartAddressPageRaw must update both
-// the directory entry's StartAddressPage byte (raw[0xEC]) and the
-// matching body-header byte 8.
+// TestSetStartAddressPageUnusedBits verifies the override mechanism
+// for canonical-SAVE byte parity: SetStartAddressPageUnusedBits must
+// set the upper 3 bits of StartAddressPage in both the directory
+// entry (raw[0xEC]) and the matching body-header byte 8 while
+// preserving the low 5 bits (the actual page index derived by
+// AddCodeFile from the load address).
 //
-// The canonical FRED 02 / Defender samdos2 install records 0x7D
-// there (0x60 decorative bits + 0x1D = page 29); AddCodeFile with
-// the same load address derives 0x1D alone. ROM masks the high bits
-// off when reading, so this is byte-parity rather than functional.
-func TestSetStartAddressPageRaw(t *testing.T) {
-	di := NewDiskImage()
-	const loadAddress = uint32(491529) // page 29 + offset 9
-	if err := di.AddCodeFile("samdos2", make([]byte, 10000), loadAddress, 0); err != nil {
-		t.Fatalf("AddCodeFile: %v", err)
+// The canonical FRED 02 / Defender samdos2 install records 0x7D there
+// (= 3<<5 | 0x1D = page 29 with the top two bits set). The bits are
+// unread by ROM and SAMDOS; this method exists for byte-perfect
+// parity with historical disk images.
+func TestSetStartAddressPageUnusedBits(t *testing.T) {
+	cases := []struct {
+		name             string
+		bits             uint8
+		wantStartAddrPg  byte
+	}{
+		{"zero (default)", 0, 0x1D},
+		{"bit 5 only", 1, 0x3D},
+		{"FRED 02 / Defender samdos2 (bits 5+6)", 3, 0x7D},
+		{"bit 7 only", 4, 0x9D},
+		{"all three (0xE0)", 7, 0xFD},
 	}
-
-	feBefore := usedFileEntry(t, di, "samdos2")
-	if feBefore.StartAddressPage != 0x1D {
-		t.Fatalf("StartAddressPage before patch = 0x%02x; want 0x1D (derived from load 491529)", feBefore.StartAddressPage)
-	}
-
-	if err := di.SetStartAddressPageRaw("samdos2", 0x7D); err != nil {
-		t.Fatalf("SetStartAddressPageRaw: %v", err)
-	}
-
-	feAfter := usedFileEntry(t, di, "samdos2")
-	if feAfter.StartAddressPage != 0x7D {
-		t.Errorf("dir entry StartAddressPage after patch = 0x%02x; want 0x7D", feAfter.StartAddressPage)
-	}
-	first := firstSectorBytes(t, di, "samdos2")
-	if first[8] != 0x7D {
-		t.Errorf("body header byte 8 after patch = 0x%02x; want 0x7D", first[8])
-	}
-	// ROM masks to 0x1F, so the decoded Start should be unchanged.
-	if got, want := feAfter.StartAddress(), loadAddress; got != want {
-		t.Errorf("decoded Start after patch = %d; want %d (decorative bits must not affect the address)", got, want)
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			di := NewDiskImage()
+			const loadAddress = uint32(491529) // page 29 + offset 9
+			if err := di.AddCodeFile("samdos2", make([]byte, 10000), loadAddress, 0); err != nil {
+				t.Fatalf("AddCodeFile: %v", err)
+			}
+			if got := usedFileEntry(t, di, "samdos2").StartAddressPage; got != 0x1D {
+				t.Fatalf("StartAddressPage before override = 0x%02x; want 0x1D (page 29, no unused bits)", got)
+			}
+			if err := di.SetStartAddressPageUnusedBits("samdos2", c.bits); err != nil {
+				t.Fatalf("SetStartAddressPageUnusedBits: %v", err)
+			}
+			fe := usedFileEntry(t, di, "samdos2")
+			if fe.StartAddressPage != c.wantStartAddrPg {
+				t.Errorf("dir entry StartAddressPage = 0x%02x; want 0x%02x", fe.StartAddressPage, c.wantStartAddrPg)
+			}
+			first := firstSectorBytes(t, di, "samdos2")
+			if first[8] != c.wantStartAddrPg {
+				t.Errorf("body header byte 8 = 0x%02x; want 0x%02x", first[8], c.wantStartAddrPg)
+			}
+			// ROM masks to 0x1F when reading, so decoded Start is unchanged.
+			if got, want := fe.StartAddress(), loadAddress; got != want {
+				t.Errorf("decoded Start after override = %d; want %d (unused bits must not affect the address)", got, want)
+			}
+		})
 	}
 }
 
-// TestSetStartAddressPageRawMissingFile confirms the helper errors
-// cleanly when the named file isn't on disk.
-func TestSetStartAddressPageRawMissingFile(t *testing.T) {
+// TestSetStartAddressPageUnusedBitsOutOfRange confirms that values
+// above 7 are rejected — the API is for 3 bits only.
+func TestSetStartAddressPageUnusedBitsOutOfRange(t *testing.T) {
 	di := NewDiskImage()
-	err := di.SetStartAddressPageRaw("nope", 0x7D)
+	if err := di.AddCodeFile("F", []byte("test"), 0x8000, 0); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+	for _, bad := range []uint8{8, 16, 32, 0x60, 0x7D, 0xFF} {
+		if err := di.SetStartAddressPageUnusedBits("F", bad); err == nil {
+			t.Errorf("SetStartAddressPageUnusedBits(%d) returned nil; want out-of-range error", bad)
+		}
+	}
+}
+
+// TestSetStartAddressPageUnusedBitsMissingFile confirms the helper
+// errors cleanly when the named file isn't on disk.
+func TestSetStartAddressPageUnusedBitsMissingFile(t *testing.T) {
+	di := NewDiskImage()
+	err := di.SetStartAddressPageUnusedBits("nope", 3)
 	if err == nil {
-		t.Fatal("SetStartAddressPageRaw returned nil error for missing file")
+		t.Fatal("SetStartAddressPageUnusedBits returned nil error for missing file")
 	}
 	if !strings.Contains(err.Error(), "nope") {
 		t.Errorf("error message = %q; want it to mention the missing filename", err.Error())


### PR DESCRIPTION
Three independent but tightly-related improvements found while migrating the sam-aarch64 M0 disk constructor off its bash+Python hybrid onto `AddCodeFile` / `AddBasicFile` (see [petemoore/sam-aarch64#4](https://github.com/petemoore/sam-aarch64/pull/4)). All three previously had to be patched in the caller; this PR moves them into samfile so downstream callers get correct on-disk bytes for free.

## 1. `FileHeader.Raw()` emits `ExecutionAddress` at body-header bytes 5-6 (functional fix)

Previously hard-coded to `0x00 0x00`. The SAM ROM's LOAD-CODE auto-exec gate at `rom-disasm:22471-22484` checks BOTH the dir entry's `ExecutionAddressDiv16K` (`raw[0xF2]`) AND body-header byte 6 — both must be `0xFF` for the loader to return cleanly to BASIC. With `AddCodeFile(..., executionAddress=0)` producing body-header byte 6 = `0x00`, a `LOAD "F" CODE addr` from BASIC would attempt to auto-exec a garbage address.

This is a real bug for any caller doing BASIC-driven CODE loading. sam-aarch64 hit it when porting its `10 CLEAR 32767: LOAD "stub" CODE 32768: CALL 32768` AUTO line over to `AddBasicFile` + `AddCodeFile`.

**Fix:** `FileHeader` gains `ExecutionAddressDiv16K uint8` and `ExecutionAddressMod16KLo uint8` fields (only the low byte of `Mod16K` fits in the 9-byte body header; the dir entry holds the full 16-bit version at `0xF3-0xF4` and stays authoritative). `FileHeader.Raw()` emits them at offsets 5 and 6; `CreateHeader()` copies them from the parent `FileEntry`; the `File()` reader populates them on parse.

## 2. `addFile` mirrors body header into `MGTFutureAndPast` (cosmetic / consistency)

Real disks written by ROM SAVE always carry the 9-byte body header duplicated into the dir entry's `MGTFutureAndPast` region at offsets 1..9 (offset 0 is reserved and stays zero). Previously `AddBasicFile` populated this explicitly but `AddCodeFile` left it zeroed, so CODE-file dir entries diverged from real-SAVE output.

**Fix:** the shared `addFile` helper now does the mirror after the header is synthesised, covering both code paths. The redundant explicit setup in `AddBasicFile` is removed.

## 3. `SetStartAddressPageUnusedBits` for byte-parity overrides (new public API)

`AddCodeFile` derives `StartAddressPage` from the load address — the low 5 bits encode the physical page index (0–31). The high 3 bits are unused: no code path in SAM ROM v3, SAMDOS 2, or MasterDOS reads them (ROM's TSURPG paging routine XORs them away via the `XOR / AND 0xE0 / XOR` idiom at `rom-disasm:14852-14859`; SAMDOS's `hsave` masks them with `AND 0x1F` at `samdos/src/h.s:140-143`).

Real-SAVE output on FRED 02 / Defender disks nonetheless records `samdos2`'s `StartAddressPage` as `0x7D` (= `3<<5 | 0x1D` = page 29 with the top two bits set) — those bits are an unmasked leak of the HMPR video-mode flags at the moment SAM ROM's BASIC SAVE wrote the byte (`rom-disasm:22866-22869`). Callers reproducing those disks byte-for-byte (e.g. for empirical comparison against a canonical reference image) previously had to patch the dir entry AND body-header byte 8 by hand.

```go
// SetStartAddressPageUnusedBits sets the upper 3 bits (bits 7..5) of
// the StartAddressPage byte for the named file, preserving the low 5
// bits. Returns an error if bits > 7 or if the file is not present.
func (di *DiskImage) SetStartAddressPageUnusedBits(name string, bits uint8) error
```

API shape rationale: a `byte` parameter would let callers silently clobber the page index. The 3-bit `uint8` (validated 0..7) makes the function's contract match what is actually variable. The name encodes the audit finding — these bits have no known consumer, so callers shouldn't reach for the API for any reason other than historical byte-parity.

The decoded `StartAddress()` is unaffected because ROM and samfile both mask to `0x1F`.

## Tests

9 new tests; existing `TestAddCodeFile*` and `TestAddBasicFile*` continue to pass unchanged:

- `TestFileHeaderRawEmitsExecutionAddress` (4 sub-cases)
- `TestAddCodeFileBodyHeaderAutoExecGate` — `executionAddress=0` ⇒ `0xff 0xff` at body-header bytes 5-6
- `TestAddCodeFileBodyHeaderExecAddrMirror` — set exec address mirrors into the body header
- `TestAddCodeFileMirrorsMGTFutureAndPast`
- `TestAddBasicFileStillMirrorsMGTFutureAndPast` — regression guard for the AddBasicFile path
- `TestSetStartAddressPageUnusedBits` (5 sub-cases: 0..7 spread across the bit positions)
- `TestSetStartAddressPageUnusedBitsOutOfRange` — values ≥ 8 rejected
- `TestSetStartAddressPageUnusedBitsMissingFile`

```
$ go test -count=1 .
ok  	github.com/petemoore/samfile/v3	0.149s
```

## Test plan

- [x] `go test -count=1 .` green
- [x] `go test -count=1 ./cmd/...` green
- [x] CI green
- [ ] Verify against `sam-aarch64` PR #4 that all three caller-side patches can be deleted once this lands.