### PR TITLE
fix: propagate StartPage to MGTFutureAndPast + BASIC body header exec gate

### DIFF
--- a/samfile.go
+++ b/samfile.go
@@ -863,6 +863,7 @@ func (di *DiskImage) SetStartAddressPageUnusedBits(name string, bits uint8) erro
 		}
 		value := (fe.StartAddressPage & 0x1F) | (bits << 5)
 		fe.StartAddressPage = value
+		fe.MGTFutureAndPast[9] = value
 		di.WriteFileEntry(dj, slot)
 		di[fe.FirstSector.Offset()+8] = value
 		return nil

--- a/samfile.go
+++ b/samfile.go
@@ -913,13 +913,24 @@ func (di *DiskImage) AddBasicFile(name string, file *sambasic.File) error {
 // the file body, by copying the directory entry's mirrored
 // metadata fields (Type, length, start-page/offset). Used by
 // addFile to construct the on-disk header for a new file.
+//
+// Body header bytes 5-6 carry the CODE execution address gate;
+// for non-CODE files they are always 0xFF — BASIC auto-RUN is
+// signalled via the directory entry's 0xF2-0xF4 bytes only
+// (see sam-file-header.md §3 and test-mgt-byte-layout.md).
 func (fe *FileEntry) CreateHeader() *FileHeader {
+	execDiv := uint8(0xFF)
+	execModLo := uint8(0xFF)
+	if fe.Type == FT_CODE {
+		execDiv = fe.ExecutionAddressDiv16K
+		execModLo = byte(fe.ExecutionAddressMod16K & 0xff)
+	}
 	return &FileHeader{
 		Type:                     fe.Type,
 		LengthMod16K:             fe.LengthMod16K,
 		PageOffset:               fe.StartAddressPageOffset,
-		ExecutionAddressDiv16K:   fe.ExecutionAddressDiv16K,
-		ExecutionAddressMod16KLo: byte(fe.ExecutionAddressMod16K & 0xff),
+		ExecutionAddressDiv16K:   execDiv,
+		ExecutionAddressMod16KLo: execModLo,
 		Pages:                    fe.Pages,
 		StartPage:                fe.StartAddressPage,
 	}

--- a/samfile_test.go
+++ b/samfile_test.go
@@ -1052,6 +1052,35 @@ func TestSetStartAddressPageUnusedBitsThreeWayConsistency(t *testing.T) {
 	}
 }
 
+// TestAddBasicFileBodyHeaderExecGate verifies that BASIC files have
+// body header bytes 5-6 set to 0xFF. The auto-exec gate in the body
+// header is a CODE-file concept; BASIC auto-RUN is signalled via the
+// directory entry's 0xF2-0xF4 bytes only (see test-mgt-byte-layout.md
+// and sam-file-header.md §3).
+func TestAddBasicFileBodyHeaderExecGate(t *testing.T) {
+	di := NewDiskImage()
+	bf := &sambasic.File{
+		Lines:     []sambasic.Line{{Number: 10, Tokens: []sambasic.Token{sambasic.PRINT, sambasic.String("hi")}}},
+		StartLine: 10,
+	}
+	if err := di.AddBasicFile("auto", bf); err != nil {
+		t.Fatalf("AddBasicFile: %v", err)
+	}
+	fe := usedFileEntry(t, di, "auto")
+	first := firstSectorBytes(t, di, "auto")
+
+	if first[5] != 0xFF || first[6] != 0xFF {
+		t.Errorf("BASIC body header bytes 5-6 = 0x%02x 0x%02x; want 0xFF 0xFF (no CODE auto-exec)", first[5], first[6])
+	}
+	// Dir entry 0xF2 should still carry the BASIC auto-RUN marker.
+	if fe.ExecutionAddressDiv16K != 0x00 {
+		t.Errorf("dir ExecutionAddressDiv16K = 0x%02x; want 0x00 (auto-RUN)", fe.ExecutionAddressDiv16K)
+	}
+	if fe.SAMBASICStartLine != 10 {
+		t.Errorf("dir SAMBASICStartLine = %d; want 10", fe.SAMBASICStartLine)
+	}
+}
+
 // TestSetStartAddressPageUnusedBitsOutOfRange confirms that values
 // above 7 are rejected — the API is for 3 bits only.
 func TestSetStartAddressPageUnusedBitsOutOfRange(t *testing.T) {

--- a/samfile_test.go
+++ b/samfile_test.go
@@ -1025,6 +1025,33 @@ func TestSetStartAddressPageUnusedBits(t *testing.T) {
 	}
 }
 
+// TestSetStartAddressPageUnusedBitsThreeWayConsistency is a property
+// test: after SetStartAddressPageUnusedBits, the StartPage byte must
+// agree across all three on-disk locations — dir 0xEC, body byte 8,
+// and the MGTFutureAndPast mirror at dir 0xDB (SAMDOS source
+// f.s:462-471, c.s:1376-1379; see BODY-MIRROR-AT-DIR-D3-DB in
+// disk-validity-rules.md).
+func TestSetStartAddressPageUnusedBitsThreeWayConsistency(t *testing.T) {
+	di := NewDiskImage()
+	if err := di.AddCodeFile("F", make([]byte, 500), 0x8000, 0); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+	if err := di.SetStartAddressPageUnusedBits("F", 5); err != nil {
+		t.Fatalf("SetStartAddressPageUnusedBits: %v", err)
+	}
+	fe := usedFileEntry(t, di, "F")
+	first := firstSectorBytes(t, di, "F")
+
+	dirEC := fe.StartAddressPage     // dir byte 0xEC
+	dirDB := fe.MGTFutureAndPast[9]  // dir byte 0xDB (mirror of body byte 8)
+	bodyB8 := first[8]               // body header byte 8
+
+	if dirEC != bodyB8 || dirEC != dirDB {
+		t.Errorf("three-way mismatch: dir[0xEC]=0x%02x, body[8]=0x%02x, MGTFutureAndPast[9]=0x%02x — all must be equal",
+			dirEC, bodyB8, dirDB)
+	}
+}
+
 // TestSetStartAddressPageUnusedBitsOutOfRange confirms that values
 // above 7 are rejected — the API is for 3 bits only.
 func TestSetStartAddressPageUnusedBitsOutOfRange(t *testing.T) {


### PR DESCRIPTION
## Summary

Two bugs in samfile's file-write APIs, found while removing caller-side patches from sam-aarch64 PR #4:

1. **`SetStartAddressPageUnusedBits` missed the MGTFutureAndPast mirror** — it updated body-header byte 8 and dir byte 0xEC but not dir byte 0xDB (`MGTFutureAndPast[9]`). Per `BODY-MIRROR-AT-DIR-D3-DB` in `disk-validity-rules.md`, dir bytes 0xD3–0xDB must exactly mirror body bytes 0–8 (SAMDOS source: `f.s:462-471`, `c.s:1376-1379`).

2. **`CreateHeader` wrote BASIC start-line into body header bytes 5-6** — those bytes are the CODE execution address gate and should be 0xFF for non-CODE files. BASIC auto-RUN is signalled via the directory entry's 0xF2-0xF4 only, not the body header (`test-mgt-byte-layout.md`: "bytes 5-6: ff ff — no auto-exec from body header").

## Test plan

- [x] `TestSetStartAddressPageUnusedBitsThreeWayConsistency` — property test: after `SetStartAddressPageUnusedBits`, dir 0xEC == body byte 8 == MGTFutureAndPast[9]
- [x] `TestAddBasicFileBodyHeaderExecGate` — BASIC file body bytes 5-6 are 0xFF; dir 0xF2 still carries the auto-RUN marker
- [x] All existing tests pass (`go test ./...`)
- [x] sam-aarch64 byte-identity test passes (Go output == Python reference)
- [x] sam-aarch64 full SimCoupé round-trip passes (`make ci`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)