### PR TITLE
verify: Phase 1 foundation (types, registry, Verify(), smoke rule, CLI)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Stray build artefacts at repo root from `go build ./cmd/samfile`
+# invocations during development. The binary's name matches the
+# samfile package name; anchor with leading / so we don't ignore
+# any future samfile/ source subdirectory.
+/samfile

--- a/cmd/samfile/main.go
+++ b/cmd/samfile/main.go
@@ -43,6 +43,10 @@ func main() {
 		basicToText(arguments)
 	case arguments["add"]:
 		add(arguments)
+	case arguments["verify"]:
+		if err := runVerify(arguments["-i"].(string)); err != nil {
+			log.Fatal(err)
+		}
 	default:
 		log.Fatal("could not find a command to run")
 	}

--- a/cmd/samfile/usage.go
+++ b/cmd/samfile/usage.go
@@ -11,6 +11,7 @@ Manipulate files in SAM Coupé floppy disk images.
     samfile cat -i IMAGE -f FILE
     samfile extract -i IMAGE [-t TARGET]
     samfile ls -i IMAGE
+    samfile verify -i IMAGE
     samfile --help
     samfile --version
 
@@ -24,6 +25,9 @@ Manipulate files in SAM Coupé floppy disk images.
     extract               Extracts all files from a SAM Disk image file to a
                           local directory.
     ls                    Lists files on SAM Disk image file.
+    verify                Checks a SAM Disk image file for structural and
+                          consistency issues, reporting findings grouped by
+                          severity.
 
   Options:
     -i IMAGE              The raw floppy disk image (.mgt format / 819200 bytes)

--- a/cmd/samfile/verify.go
+++ b/cmd/samfile/verify.go
@@ -55,6 +55,10 @@ func runVerify(imagePath string) error {
 		fmt.Printf("%s (%d):\n", strings.ToUpper(s.String()), len(findings))
 		for _, f := range findings {
 			fmt.Printf("  [%s]", f.RuleID)
+			// TODO(phase 3+): when a Rule uses SectorLocation, render
+			// Sector (track/sector) and ByteOffset here too. Phase 1 has
+			// no SectorLocation users so this formatter only handles
+			// disk-wide and slot-level locations.
 			if !f.Location.IsDiskWide() {
 				fmt.Printf(" slot %d", f.Location.Slot)
 				if f.Location.Filename != "" {

--- a/cmd/samfile/verify.go
+++ b/cmd/samfile/verify.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/petemoore/samfile/v3"
+)
+
+// runVerify is the entry point for the `samfile verify` subcommand.
+// Phase 1 implements the minimum useful behaviour: load the disk,
+// call Verify, print findings grouped by severity, return nil
+// unless a fatal finding is present (in which case return a non-nil
+// error so main exits non-zero).
+//
+// CLI flags (--severity, --json, --dialect, --rule, --quiet, --all)
+// are deferred to a later phase. Phase 1 always shows every finding
+// regardless of severity, so the smoke test can see DISK-NOT-EMPTY.
+//
+// Signature note: existing subcommands (ls, cat, etc.) take a
+// docopt.Opts map and call log.Fatal on error. runVerify deviates
+// deliberately — Task 9 defines it as an isolated, testable unit
+// (image-path in, error out); Task 10 wires it into the dispatcher
+// by extracting arguments["-i"].(string) and calling log.Fatal on
+// a non-nil return.
+func runVerify(imagePath string) error {
+	di, err := samfile.Load(imagePath)
+	if err != nil {
+		return fmt.Errorf("verify: %w", err)
+	}
+
+	report := di.Verify()
+
+	fmt.Printf("samfile verify: results for %s\n", imagePath)
+	fmt.Printf("detected dialect: %s\n", report.Dialect)
+	fmt.Println()
+
+	if len(report.Findings) == 0 {
+		fmt.Println("no findings.")
+		return nil
+	}
+
+	// Group by severity, highest first.
+	severities := []samfile.Severity{
+		samfile.SeverityFatal,
+		samfile.SeverityStructural,
+		samfile.SeverityInconsistency,
+		samfile.SeverityCosmetic,
+	}
+	for _, s := range severities {
+		findings := report.BySeverity(s)
+		if len(findings) == 0 {
+			continue
+		}
+		fmt.Printf("%s (%d):\n", strings.ToUpper(s.String()), len(findings))
+		for _, f := range findings {
+			fmt.Printf("  [%s]", f.RuleID)
+			if !f.Location.IsDiskWide() {
+				fmt.Printf(" slot %d", f.Location.Slot)
+				if f.Location.Filename != "" {
+					fmt.Printf(" (%s)", f.Location.Filename)
+				}
+			}
+			fmt.Println()
+			fmt.Printf("    %s\n", f.Message)
+			fmt.Printf("    citation: %s\n", f.Citation)
+		}
+		fmt.Println()
+	}
+
+	fmt.Printf("%d finding(s).\n", len(report.Findings))
+	if report.HasFatal() {
+		return fmt.Errorf("verify: %d fatal finding(s)", len(report.BySeverity(samfile.SeverityFatal)))
+	}
+	return nil
+}

--- a/cmd/samfile/verify_test.go
+++ b/cmd/samfile/verify_test.go
@@ -55,6 +55,89 @@ func TestVerifyCmdOnEmptyDisk(t *testing.T) {
 	}
 }
 
+// TestVerifyCmdOnFatalFinding exercises the fatal-findings exit
+// path in runVerify. Phase 1's only rule is severity
+// Inconsistency, so this test registers a synthetic fatal rule,
+// then confirms runVerify returns a non-nil error mentioning
+// "fatal".
+//
+// Caveat: the rule registry is package-private to samfile and
+// exposes no Unregister. We can only call samfile.Register
+// additively from this test package, and the registered rule
+// will run for every later test in the same process. Two
+// workarounds keep things sane:
+//
+//  1. alreadyRegistered guard — under `go test -count=N` the same
+//     test runs N times in one process; without this guard the
+//     second iteration would panic on duplicate-ID registration.
+//
+//  2. Marker-file gate — the rule's Check fires only when slot 0
+//     of the disk under inspection contains a file whose name
+//     starts with "FATAL-MARK". The sibling tests use plain "F",
+//     so the rule is invisible to them even though it's in the
+//     registry. This is a Phase-1 limitation; Phase 2+ may
+//     revisit it when corpus-validation tests need fully-clean
+//     registries (e.g. by adding samfile.Unregister or a
+//     TestMain-scoped registry snapshot).
+func TestVerifyCmdOnFatalFinding(t *testing.T) {
+	alreadyRegistered := false
+	for _, r := range samfile.Rules() {
+		if r.ID == "TEST-FATAL" {
+			alreadyRegistered = true
+			break
+		}
+	}
+	if !alreadyRegistered {
+		samfile.Register(samfile.Rule{
+			ID:          "TEST-FATAL",
+			Severity:    samfile.SeverityFatal,
+			Description: "always fatal (gated on FATAL-MARK marker file)",
+			Citation:    "test",
+			Check: func(ctx *samfile.CheckContext) []samfile.Finding {
+				// Gate on a marker filename so this rule is
+				// invisible to the sibling CLI tests that share
+				// the same process registry.
+				dj := ctx.Disk.DiskJournal()
+				if dj[0] == nil {
+					return nil
+				}
+				name := strings.TrimRight(string(dj[0].Name[:]), " ")
+				if !strings.HasPrefix(name, "FATAL-MARK") {
+					return nil
+				}
+				return []samfile.Finding{{
+					RuleID:   "TEST-FATAL",
+					Severity: samfile.SeverityFatal,
+					Location: samfile.DiskWideLocation(),
+					Message:  "synthetic fatal for testing",
+					Citation: "test",
+				}}
+			},
+		})
+	}
+
+	di := samfile.NewDiskImage()
+	if err := di.AddCodeFile("FATAL-MARK", []byte("hi"), 0x8000, 0); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "test.mgt")
+	if err := di.Save(imgPath); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	_, err := captureVerify(t, imgPath)
+	if err == nil {
+		t.Fatal("runVerify returned nil error; expected non-nil for fatal finding")
+	}
+	if !strings.Contains(err.Error(), "verify:") {
+		t.Errorf("error message = %q; want prefix 'verify:'", err.Error())
+	}
+	if !strings.Contains(err.Error(), "fatal") {
+		t.Errorf("error message = %q; want to mention 'fatal'", err.Error())
+	}
+}
+
 // captureVerify invokes the verify subcommand and returns its stdout.
 func captureVerify(t *testing.T, imgPath string) (string, error) {
 	t.Helper()

--- a/cmd/samfile/verify_test.go
+++ b/cmd/samfile/verify_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/petemoore/samfile/v3"
+)
+
+// TestVerifyCmdOnPopulatedDisk runs the CLI subcommand against a
+// disk built in-memory with one CODE file. Expected: DISK-NOT-EMPTY
+// does not fire; output reports no findings; exit code (returned
+// as nil error) is clean.
+func TestVerifyCmdOnPopulatedDisk(t *testing.T) {
+	di := samfile.NewDiskImage()
+	if err := di.AddCodeFile("F", []byte("hello"), 0x8000, 0); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "test.mgt")
+	if err := di.Save(imgPath); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	stdout, err := captureVerify(t, imgPath)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "no findings") {
+		t.Errorf("expected 'no findings' in output; got:\n%s", stdout)
+	}
+}
+
+// TestVerifyCmdOnEmptyDisk runs against an empty disk. Expected:
+// DISK-NOT-EMPTY fires; output mentions the rule ID; error is nil
+// (inconsistency does not gate exit code).
+func TestVerifyCmdOnEmptyDisk(t *testing.T) {
+	di := samfile.NewDiskImage()
+	dir := t.TempDir()
+	imgPath := filepath.Join(dir, "test.mgt")
+	if err := di.Save(imgPath); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	stdout, err := captureVerify(t, imgPath)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if !strings.Contains(stdout, "DISK-NOT-EMPTY") {
+		t.Errorf("expected 'DISK-NOT-EMPTY' in output; got:\n%s", stdout)
+	}
+}
+
+// captureVerify invokes the verify subcommand and returns its stdout.
+func captureVerify(t *testing.T, imgPath string) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	defer func() { os.Stdout = old }()
+
+	err := runVerify(imgPath)
+
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String(), err
+}

--- a/rules_smoke.go
+++ b/rules_smoke.go
@@ -1,0 +1,34 @@
+package samfile
+
+import "fmt"
+
+// DISK-NOT-EMPTY is the Phase 1 smoke-test rule: it fires on a disk
+// with zero occupied directory entries. The "real" rule catalog has
+// dozens of these; this is the one we wire up end-to-end in Phase 1
+// to prove the registry + Verify plumbing works. Severity is
+// inconsistency rather than fatal because an empty disk is unusual
+// but technically valid SAM-format output.
+func init() {
+	Register(Rule{
+		ID:          "DISK-NOT-EMPTY",
+		Severity:    SeverityInconsistency,
+		Dialects:    nil, // all dialects
+		Description: "disk has at least one occupied directory entry",
+		Citation:    "docs/disk-validity-rules.md",
+		Check:       checkDiskNotEmpty,
+	})
+}
+
+func checkDiskNotEmpty(ctx *CheckContext) []Finding {
+	used := ctx.Journal.UsedFileEntries()
+	if len(used) > 0 {
+		return nil
+	}
+	return []Finding{{
+		RuleID:   "DISK-NOT-EMPTY",
+		Severity: SeverityInconsistency,
+		Location: DiskWideLocation(),
+		Message:  fmt.Sprintf("disk has 0 occupied directory entries (all %d slots are free)", len(ctx.Journal.FreeFileEntries())),
+		Citation: "docs/disk-validity-rules.md",
+	}}
+}

--- a/rules_smoke_test.go
+++ b/rules_smoke_test.go
@@ -1,0 +1,58 @@
+package samfile
+
+import (
+	"testing"
+)
+
+func TestDiskNotEmptyRulePositive(t *testing.T) {
+	di := NewDiskImage()
+	if err := di.AddCodeFile("A", []byte("hello"), 0x8000, 0); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+	findings := checkDiskNotEmpty(&CheckContext{
+		Disk:    di,
+		Journal: di.DiskJournal(),
+		Dialect: DialectUnknown,
+	})
+	if len(findings) != 0 {
+		t.Errorf("checkDiskNotEmpty on populated disk returned %d findings; want 0", len(findings))
+	}
+}
+
+func TestDiskNotEmptyRuleNegative(t *testing.T) {
+	di := NewDiskImage()
+	findings := checkDiskNotEmpty(&CheckContext{
+		Disk:    di,
+		Journal: di.DiskJournal(),
+		Dialect: DialectUnknown,
+	})
+	if len(findings) != 1 {
+		t.Fatalf("checkDiskNotEmpty on empty disk returned %d findings; want 1", len(findings))
+	}
+	f := findings[0]
+	if f.RuleID != "DISK-NOT-EMPTY" {
+		t.Errorf("RuleID = %q; want DISK-NOT-EMPTY", f.RuleID)
+	}
+	if f.Severity != SeverityInconsistency {
+		t.Errorf("Severity = %v; want inconsistency", f.Severity)
+	}
+	if !f.Location.IsDiskWide() {
+		t.Errorf("Location.IsDiskWide() = false; want true")
+	}
+	if f.Message == "" {
+		t.Error("Message empty")
+	}
+}
+
+func TestDiskNotEmptyRegistered(t *testing.T) {
+	found := false
+	for _, r := range Rules() {
+		if r.ID == "DISK-NOT-EMPTY" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("DISK-NOT-EMPTY rule not in registry")
+	}
+}

--- a/verify.go
+++ b/verify.go
@@ -105,3 +105,46 @@ type Finding struct {
 	Message  string
 	Citation string
 }
+
+// Rule is a registered validity check. Check is invoked once per
+// Verify run and returns zero or more Findings. Rule values are
+// immutable after registration.
+type Rule struct {
+	ID          string // catalog-stable, e.g. "DISK-NOT-EMPTY"
+	Severity    Severity
+	Dialects    []Dialect // dialects the rule applies to; nil/empty = all
+	Description string    // one-line summary, used in human output
+	Citation    string    // file:line of the strongest evidence
+	Check       func(ctx *CheckContext) []Finding
+}
+
+// allRules is the package-private registry. Rules register at package
+// init time via Register; the order is preserved so Verify output is
+// deterministic.
+var allRules []Rule
+
+// Register adds rule to the package-wide rule registry. Panics if a
+// rule with the same ID is already registered (rule IDs must be
+// catalog-stable and unique). Intended to be called from init().
+func Register(rule Rule) {
+	for _, r := range allRules {
+		if r.ID == rule.ID {
+			panic("samfile: duplicate rule ID registered: " + rule.ID)
+		}
+	}
+	allRules = append(allRules, rule)
+}
+
+// Rules returns a copy of the registered rules in registration
+// order. Use this for inspection (e.g. CLI help, documentation
+// generators); Verify iterates allRules directly.
+func Rules() []Rule {
+	out := make([]Rule, len(allRules))
+	copy(out, allRules)
+	return out
+}
+
+// CheckContext is defined in full in Task 5. Forward declaration so
+// Rule.Check's signature compiles. Will be expanded with Disk,
+// Journal, and Dialect fields.
+type CheckContext struct{}

--- a/verify.go
+++ b/verify.go
@@ -144,7 +144,14 @@ func Rules() []Rule {
 	return out
 }
 
-// CheckContext is defined in full in Task 5. Forward declaration so
-// Rule.Check's signature compiles. Will be expanded with Disk,
-// Journal, and Dialect fields.
-type CheckContext struct{}
+// CheckContext is the read-only environment passed to each Rule's
+// Check function. All disk inspection should go through ctx — Rules
+// must NOT call disk.DiskJournal() themselves (the journal is
+// computed once per Verify run and shared). If a future rule needs
+// another expensive derivation (e.g. a combined sector map), add
+// it as a field on CheckContext and memoise it in Verify.
+type CheckContext struct {
+	Disk    *DiskImage
+	Journal *DiskJournal
+	Dialect Dialect
+}

--- a/verify.go
+++ b/verify.go
@@ -155,3 +155,92 @@ type CheckContext struct {
 	Journal *DiskJournal
 	Dialect Dialect
 }
+
+// VerifyReport is the result of running Verify on a DiskImage.
+// Findings is the full ordered slice; the helper methods filter
+// without mutating.
+type VerifyReport struct {
+	Dialect  Dialect
+	Findings []Finding
+}
+
+// HasFatal reports whether any finding has severity SeverityFatal.
+func (r VerifyReport) HasFatal() bool {
+	for _, f := range r.Findings {
+		if f.Severity == SeverityFatal {
+			return true
+		}
+	}
+	return false
+}
+
+// HasStructural reports whether any finding has severity
+// SeverityStructural or higher.
+func (r VerifyReport) HasStructural() bool {
+	for _, f := range r.Findings {
+		if f.Severity >= SeverityStructural {
+			return true
+		}
+	}
+	return false
+}
+
+// BySeverity returns findings with exactly the given severity, in
+// registration order.
+func (r VerifyReport) BySeverity(s Severity) []Finding {
+	var out []Finding
+	for _, f := range r.Findings {
+		if f.Severity == s {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// ByRule returns findings produced by the rule with the given ID,
+// in registration order.
+func (r VerifyReport) ByRule(ruleID string) []Finding {
+	var out []Finding
+	for _, f := range r.Findings {
+		if f.RuleID == ruleID {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// FilterOpts controls VerifyReport.Filter. Zero-value fields act
+// as "no constraint".
+type FilterOpts struct {
+	MinSeverity Severity // findings with severity >= MinSeverity pass
+	Rules       []string // if non-empty, only these rule IDs pass
+	Slot        *int     // if non-nil, only findings at this slot pass
+}
+
+// Filter returns findings matching every set constraint in opts, in
+// registration order. An empty FilterOpts returns r.Findings.
+func (r VerifyReport) Filter(opts FilterOpts) []Finding {
+	var out []Finding
+	for _, f := range r.Findings {
+		if f.Severity < opts.MinSeverity {
+			continue
+		}
+		if len(opts.Rules) > 0 {
+			matched := false
+			for _, id := range opts.Rules {
+				if f.RuleID == id {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
+		}
+		if opts.Slot != nil && f.Location.Slot != *opts.Slot {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}

--- a/verify.go
+++ b/verify.go
@@ -1,6 +1,13 @@
 package samfile
 
+import "fmt"
+
 // Severity ranks findings by impact, lowest to highest.
+//
+// Severity names are stable public API; the numeric values
+// assigned by iota are NOT — new severities may be inserted
+// between existing ones, shifting integer values. Don't serialise
+// the raw int.
 type Severity int
 
 const (
@@ -24,7 +31,7 @@ func (s Severity) String() string {
 	case SeverityFatal:
 		return "fatal"
 	}
-	return "unknown"
+	return fmt.Sprintf("Severity(%d)", s)
 }
 
 // Dialect identifies which DOS produced the disk. Phase 1 only
@@ -52,7 +59,7 @@ func (d Dialect) String() string {
 	case DialectMasterDOS:
 		return "masterdos"
 	}
-	return "unknown"
+	return fmt.Sprintf("Dialect(%d)", d)
 }
 
 // Location pinpoints a Finding on the disk. Construct one via the
@@ -63,7 +70,7 @@ type Location struct {
 	Slot       int     // -1 if not applicable, else 0..79
 	Sector     *Sector // nil if not applicable
 	ByteOffset int     // -1 if not applicable, else byte offset within Sector
-	Filename   string  // copied from Slot's directory entry when known, for messages
+	Filename   string  // file name from the slot's directory entry, embedded for message formatting; "" when Slot is -1
 }
 
 // DiskWideLocation returns a Location for findings that apply to the
@@ -211,6 +218,12 @@ func (r VerifyReport) ByRule(ruleID string) []Finding {
 
 // FilterOpts controls VerifyReport.Filter. Zero-value fields act
 // as "no constraint".
+//
+// FilterOpts intentionally has no Dialect field: a VerifyReport
+// has a single Dialect for the whole disk, so per-finding
+// dialect filtering would be meaningless. If you need to scope
+// by dialect, do so on the report producer (or pass --dialect
+// on the CLI).
 type FilterOpts struct {
 	MinSeverity Severity // findings with severity >= MinSeverity pass
 	Rules       []string // if non-empty, only these rule IDs pass

--- a/verify.go
+++ b/verify.go
@@ -54,3 +54,37 @@ func (d Dialect) String() string {
 	}
 	return "unknown"
 }
+
+// Location pinpoints a Finding on the disk. Construct one via the
+// DiskWideLocation, SlotLocation, or SectorLocation factories — they
+// set the "not applicable" sentinels correctly. The zero value of
+// Location is NOT a valid disk-wide location (Slot=0 is a real slot).
+type Location struct {
+	Slot       int     // -1 if not applicable, else 0..79
+	Sector     *Sector // nil if not applicable
+	ByteOffset int     // -1 if not applicable, else byte offset within Sector
+	Filename   string  // copied from Slot's directory entry when known, for messages
+}
+
+// DiskWideLocation returns a Location for findings that apply to the
+// disk image as a whole (no specific slot or sector).
+func DiskWideLocation() Location {
+	return Location{Slot: -1, Sector: nil, ByteOffset: -1}
+}
+
+// SlotLocation returns a Location for findings tied to a specific
+// directory slot but not a specific sector or byte.
+func SlotLocation(slot int, filename string) Location {
+	return Location{Slot: slot, Sector: nil, ByteOffset: -1, Filename: filename}
+}
+
+// SectorLocation returns a Location for findings tied to a specific
+// byte within a specific sector of a specific file.
+func SectorLocation(slot int, filename string, sector *Sector, byteOffset int) Location {
+	return Location{Slot: slot, Sector: sector, ByteOffset: byteOffset, Filename: filename}
+}
+
+// IsDiskWide reports whether loc has no slot, sector, or byte set.
+func (loc Location) IsDiskWide() bool {
+	return loc.Slot == -1 && loc.Sector == nil && loc.ByteOffset == -1
+}

--- a/verify.go
+++ b/verify.go
@@ -88,3 +88,20 @@ func SectorLocation(slot int, filename string, sector *Sector, byteOffset int) L
 func (loc Location) IsDiskWide() bool {
 	return loc.Slot == -1 && loc.Sector == nil && loc.ByteOffset == -1
 }
+
+// Finding is one specific violation produced by one Rule.
+//
+// Message is the prose summary intended for human readers
+// (default CLI output prints it directly). It should be a
+// single line including the relevant Expected vs Actual
+// values; multi-line context goes in a separate diagnostic.
+//
+// Citation duplicates the parent Rule's citation for easy
+// access without a registry lookup.
+type Finding struct {
+	RuleID   string
+	Severity Severity
+	Location Location
+	Message  string
+	Citation string
+}

--- a/verify.go
+++ b/verify.go
@@ -1,0 +1,56 @@
+package samfile
+
+// Severity ranks findings by impact, lowest to highest.
+type Severity int
+
+const (
+	SeverityCosmetic Severity = iota
+	SeverityInconsistency
+	SeverityStructural
+	SeverityFatal
+)
+
+// String returns the lowercase canonical name of the severity,
+// matching the names used by the disk-validity-rules.md catalog
+// and the CLI's --severity flag.
+func (s Severity) String() string {
+	switch s {
+	case SeverityCosmetic:
+		return "cosmetic"
+	case SeverityInconsistency:
+		return "inconsistency"
+	case SeverityStructural:
+		return "structural"
+	case SeverityFatal:
+		return "fatal"
+	}
+	return "unknown"
+}
+
+// Dialect identifies which DOS produced the disk. Phase 1 only
+// uses DialectUnknown (dialect detection lands in Phase 2); rules
+// are scoped by their Dialects slice, with nil meaning all dialects.
+type Dialect int
+
+const (
+	DialectUnknown Dialect = iota
+	DialectSAMDOS1
+	DialectSAMDOS2
+	DialectMasterDOS
+)
+
+// String returns the lowercase canonical name of the dialect,
+// matching the CLI's --dialect flag.
+func (d Dialect) String() string {
+	switch d {
+	case DialectUnknown:
+		return "unknown"
+	case DialectSAMDOS1:
+		return "samdos1"
+	case DialectSAMDOS2:
+		return "samdos2"
+	case DialectMasterDOS:
+		return "masterdos"
+	}
+	return "unknown"
+}

--- a/verify.go
+++ b/verify.go
@@ -244,3 +244,44 @@ func (r VerifyReport) Filter(opts FilterOpts) []Finding {
 	}
 	return out
 }
+
+// Verify runs all registered rules against di and returns a report
+// describing the disk's structural state. The report is always
+// populated — individual rule failures are surfaced as Findings,
+// not Go errors. Verify itself does not return an error.
+//
+// In Phase 1, dialect detection is not yet implemented and Verify
+// always passes DialectUnknown to rules; rules whose Dialects slice
+// is non-empty and excludes DialectUnknown are skipped. Phase 2
+// adds DetectDialect.
+func (di *DiskImage) Verify() VerifyReport {
+	dialect := DialectUnknown
+	ctx := &CheckContext{
+		Disk:    di,
+		Journal: di.DiskJournal(),
+		Dialect: dialect,
+	}
+	report := VerifyReport{Dialect: dialect}
+	for _, rule := range allRules {
+		if !ruleAppliesToDialect(rule, dialect) {
+			continue
+		}
+		report.Findings = append(report.Findings, rule.Check(ctx)...)
+	}
+	return report
+}
+
+// ruleAppliesToDialect reports whether rule should run when the
+// detected dialect is d. A rule with no Dialects field set (nil or
+// empty) applies to all dialects.
+func ruleAppliesToDialect(rule Rule, d Dialect) bool {
+	if len(rule.Dialects) == 0 {
+		return true
+	}
+	for _, allowed := range rule.Dialects {
+		if allowed == d {
+			return true
+		}
+	}
+	return false
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -22,6 +22,7 @@ func TestSeverityString(t *testing.T) {
 		{SeverityInconsistency, "inconsistency"},
 		{SeverityStructural, "structural"},
 		{SeverityFatal, "fatal"},
+		{Severity(99), "Severity(99)"},
 	}
 	for _, c := range cases {
 		if got := c.sev.String(); got != c.want {
@@ -39,6 +40,7 @@ func TestDialectString(t *testing.T) {
 		{DialectSAMDOS1, "samdos1"},
 		{DialectSAMDOS2, "samdos2"},
 		{DialectMasterDOS, "masterdos"},
+		{Dialect(99), "Dialect(99)"},
 	}
 	for _, c := range cases {
 		if got := c.d.String(); got != c.want {
@@ -60,7 +62,7 @@ func TestLocationDiskWide(t *testing.T) {
 func TestLocationSlot(t *testing.T) {
 	loc := SlotLocation(3, "IN")
 	if loc.IsDiskWide() {
-		t.Errorf("SlotLocation(3).IsDiskWide() = true; want false")
+		t.Errorf(`SlotLocation(3, "IN").IsDiskWide() = true; want false`)
 	}
 	if loc.Slot != 3 {
 		t.Errorf("Slot = %d; want 3", loc.Slot)
@@ -79,8 +81,17 @@ func TestLocationSector(t *testing.T) {
 	if loc.IsDiskWide() {
 		t.Errorf("SectorLocation.IsDiskWide() = true; want false")
 	}
-	if loc.Slot != 2 || loc.Filename != "stub" || loc.Sector != sec || loc.ByteOffset != 8 {
-		t.Errorf("SectorLocation fields wrong; got %+v", loc)
+	if loc.Slot != 2 {
+		t.Errorf("Slot = %d; want 2", loc.Slot)
+	}
+	if loc.Filename != "stub" {
+		t.Errorf("Filename = %q; want %q", loc.Filename, "stub")
+	}
+	if loc.Sector != sec {
+		t.Errorf("Sector pointer mismatch")
+	}
+	if loc.ByteOffset != 8 {
+		t.Errorf("ByteOffset = %d; want 8", loc.ByteOffset)
 	}
 }
 
@@ -101,8 +112,11 @@ func TestFindingShape(t *testing.T) {
 	if f.Location.Slot != 2 || f.Location.Filename != "stub" {
 		t.Errorf("Location fields wrong; got %+v", f.Location)
 	}
-	if f.Message == "" || f.Citation == "" {
-		t.Errorf("Message and Citation should be populated")
+	if f.Message != "expected X, got Y" {
+		t.Errorf("Message = %q; want %q", f.Message, "expected X, got Y")
+	}
+	if f.Citation != "samdos/src/c.s:1306-1343" {
+		t.Errorf("Citation = %q; want %q", f.Citation, "samdos/src/c.s:1306-1343")
 	}
 }
 
@@ -123,6 +137,13 @@ func TestRegisterAndIterate(t *testing.T) {
 	}
 	if got[0].ID != "TEST-A" || got[1].ID != "TEST-B" {
 		t.Errorf("Rules() out of registration order: %+v", got)
+	}
+
+	// Mutating the returned slice must not affect the registry —
+	// Rules() guarantees a defensive copy.
+	got[0].ID = "MUTATED"
+	if Rules()[0].ID != "TEST-A" {
+		t.Error("Rules() returned the underlying slice, not a copy")
 	}
 }
 
@@ -188,6 +209,22 @@ func TestVerifyReportHelpers(t *testing.T) {
 	}
 	if got := r.Filter(FilterOpts{Rules: []string{"A"}}); len(got) != 1 {
 		t.Errorf("Filter(rules=[A]) returned %d; want 1", len(got))
+	}
+
+	// FilterOpts.Slot path (*int sentinel)
+	slot2 := 2
+	if got := r.Filter(FilterOpts{Slot: &slot2}); len(got) != 1 || got[0].Location.Filename != "stub" {
+		t.Errorf("Filter(slot=2) returned %d findings; want 1 (slot 2 = stub)", len(got))
+	}
+
+	// Negative-path: rule that doesn't exist
+	if got := r.ByRule("DOES-NOT-EXIST"); len(got) != 0 {
+		t.Errorf("ByRule(missing) returned %d; want 0", len(got))
+	}
+
+	// Negative-path: severity not present in fixture
+	if got := r.BySeverity(SeverityInconsistency); len(got) != 0 {
+		t.Errorf("BySeverity(inconsistency) returned %d; want 0 (fixture has none)", len(got))
 	}
 }
 

--- a/verify_test.go
+++ b/verify_test.go
@@ -105,3 +105,37 @@ func TestFindingShape(t *testing.T) {
 		t.Errorf("Message and Citation should be populated")
 	}
 }
+
+func TestRegisterAndIterate(t *testing.T) {
+	// Snapshot the registry, clear it for this test, restore after.
+	saved := append([]Rule(nil), allRules...)
+	allRules = nil
+	defer func() { allRules = saved }()
+
+	r1 := Rule{ID: "TEST-A", Severity: SeverityCosmetic, Description: "a", Citation: "x:1"}
+	r2 := Rule{ID: "TEST-B", Severity: SeverityFatal, Description: "b", Citation: "x:2"}
+	Register(r1)
+	Register(r2)
+
+	got := Rules()
+	if len(got) != 2 {
+		t.Fatalf("Rules() returned %d entries; want 2", len(got))
+	}
+	if got[0].ID != "TEST-A" || got[1].ID != "TEST-B" {
+		t.Errorf("Rules() out of registration order: %+v", got)
+	}
+}
+
+func TestRegisterRejectsDuplicateID(t *testing.T) {
+	saved := append([]Rule(nil), allRules...)
+	allRules = nil
+	defer func() { allRules = saved }()
+
+	Register(Rule{ID: "DUP", Severity: SeverityFatal, Description: "x", Citation: "x:1"})
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Register with duplicate ID did not panic")
+		}
+	}()
+	Register(Rule{ID: "DUP", Severity: SeverityFatal, Description: "y", Citation: "x:2"})
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -158,3 +158,42 @@ func TestCheckContextShape(t *testing.T) {
 		t.Errorf("ctx.Dialect = %v; want samdos2", ctx.Dialect)
 	}
 }
+
+func TestVerifyReportHelpers(t *testing.T) {
+	r := VerifyReport{
+		Dialect: DialectSAMDOS2,
+		Findings: []Finding{
+			{RuleID: "A", Severity: SeverityFatal, Location: DiskWideLocation()},
+			{RuleID: "B", Severity: SeverityStructural, Location: SlotLocation(2, "stub")},
+			{RuleID: "C", Severity: SeverityCosmetic, Location: DiskWideLocation()},
+			{RuleID: "B", Severity: SeverityStructural, Location: SlotLocation(3, "IN")},
+		},
+	}
+
+	if !r.HasFatal() {
+		t.Error("HasFatal() = false; want true")
+	}
+	if !r.HasStructural() {
+		t.Error("HasStructural() = false; want true")
+	}
+
+	if got := r.BySeverity(SeverityStructural); len(got) != 2 {
+		t.Errorf("BySeverity(structural) returned %d; want 2", len(got))
+	}
+	if got := r.ByRule("B"); len(got) != 2 {
+		t.Errorf("ByRule(B) returned %d; want 2", len(got))
+	}
+	if got := r.Filter(FilterOpts{MinSeverity: SeverityStructural}); len(got) != 3 {
+		t.Errorf("Filter(min=structural) returned %d; want 3 (B, A, B in registration order)", len(got))
+	}
+	if got := r.Filter(FilterOpts{Rules: []string{"A"}}); len(got) != 1 {
+		t.Errorf("Filter(rules=[A]) returned %d; want 1", len(got))
+	}
+}
+
+func TestVerifyReportHasFatalEmpty(t *testing.T) {
+	r := VerifyReport{}
+	if r.HasFatal() || r.HasStructural() {
+		t.Error("empty report should not report Has*")
+	}
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -1,0 +1,48 @@
+package samfile
+
+import (
+	"testing"
+)
+
+func TestSeverityOrdering(t *testing.T) {
+	if !(SeverityCosmetic < SeverityInconsistency &&
+		SeverityInconsistency < SeverityStructural &&
+		SeverityStructural < SeverityFatal) {
+		t.Fatalf("Severity constants out of order: cosmetic=%d inconsistency=%d structural=%d fatal=%d",
+			SeverityCosmetic, SeverityInconsistency, SeverityStructural, SeverityFatal)
+	}
+}
+
+func TestSeverityString(t *testing.T) {
+	cases := []struct {
+		sev  Severity
+		want string
+	}{
+		{SeverityCosmetic, "cosmetic"},
+		{SeverityInconsistency, "inconsistency"},
+		{SeverityStructural, "structural"},
+		{SeverityFatal, "fatal"},
+	}
+	for _, c := range cases {
+		if got := c.sev.String(); got != c.want {
+			t.Errorf("Severity(%d).String() = %q; want %q", c.sev, got, c.want)
+		}
+	}
+}
+
+func TestDialectString(t *testing.T) {
+	cases := []struct {
+		d    Dialect
+		want string
+	}{
+		{DialectUnknown, "unknown"},
+		{DialectSAMDOS1, "samdos1"},
+		{DialectSAMDOS2, "samdos2"},
+		{DialectMasterDOS, "masterdos"},
+	}
+	for _, c := range cases {
+		if got := c.d.String(); got != c.want {
+			t.Errorf("Dialect(%d).String() = %q; want %q", c.d, got, c.want)
+		}
+	}
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -197,3 +197,87 @@ func TestVerifyReportHasFatalEmpty(t *testing.T) {
 		t.Error("empty report should not report Has*")
 	}
 }
+
+func TestVerifyRunsRegisteredRules(t *testing.T) {
+	saved := append([]Rule(nil), allRules...)
+	allRules = nil
+	defer func() { allRules = saved }()
+
+	called := 0
+	Register(Rule{
+		ID:          "X-1",
+		Severity:    SeverityFatal,
+		Description: "always fires",
+		Citation:    "test",
+		Check: func(ctx *CheckContext) []Finding {
+			called++
+			return []Finding{{
+				RuleID:   "X-1",
+				Severity: SeverityFatal,
+				Location: DiskWideLocation(),
+				Message:  "test finding",
+				Citation: "test",
+			}}
+		},
+	})
+
+	di := NewDiskImage()
+	report := di.Verify()
+
+	if called != 1 {
+		t.Errorf("Check called %d times; want 1", called)
+	}
+	if len(report.Findings) != 1 {
+		t.Fatalf("Findings = %d; want 1", len(report.Findings))
+	}
+	if report.Findings[0].RuleID != "X-1" {
+		t.Errorf("Findings[0].RuleID = %q; want X-1", report.Findings[0].RuleID)
+	}
+}
+
+func TestVerifyRespectsDialectScoping(t *testing.T) {
+	saved := append([]Rule(nil), allRules...)
+	allRules = nil
+	defer func() { allRules = saved }()
+
+	allDialects := 0
+	scoped := 0
+	Register(Rule{
+		ID:          "ALL",
+		Severity:    SeverityCosmetic,
+		Description: "all dialects",
+		Citation:    "test",
+		Check:       func(ctx *CheckContext) []Finding { allDialects++; return nil },
+	})
+	Register(Rule{
+		ID:          "MASTERDOS-ONLY",
+		Severity:    SeverityCosmetic,
+		Dialects:    []Dialect{DialectMasterDOS},
+		Description: "masterdos only",
+		Citation:    "test",
+		Check:       func(ctx *CheckContext) []Finding { scoped++; return nil },
+	})
+
+	di := NewDiskImage()
+	di.Verify() // Phase 1 always passes DialectUnknown
+
+	if allDialects != 1 {
+		t.Errorf("all-dialects rule called %d times; want 1", allDialects)
+	}
+	if scoped != 0 {
+		t.Errorf("masterdos-only rule called %d times; want 0 (dialect is Unknown)", scoped)
+	}
+}
+
+func TestVerifyReportCarriesDialect(t *testing.T) {
+	saved := append([]Rule(nil), allRules...)
+	allRules = nil
+	defer func() { allRules = saved }()
+
+	di := NewDiskImage()
+	report := di.Verify()
+	// Phase 1: dialect detection is not implemented; always DialectUnknown.
+	if report.Dialect != DialectUnknown {
+		t.Errorf("Dialect = %v; want unknown (detection lands in Phase 2)", report.Dialect)
+	}
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -83,3 +83,25 @@ func TestLocationSector(t *testing.T) {
 		t.Errorf("SectorLocation fields wrong; got %+v", loc)
 	}
 }
+
+func TestFindingShape(t *testing.T) {
+	f := Finding{
+		RuleID:   "TEST-RULE",
+		Severity: SeverityStructural,
+		Location: SlotLocation(2, "stub"),
+		Message:  "expected X, got Y",
+		Citation: "samdos/src/c.s:1306-1343",
+	}
+	if f.RuleID != "TEST-RULE" {
+		t.Errorf("RuleID = %q; want TEST-RULE", f.RuleID)
+	}
+	if f.Severity != SeverityStructural {
+		t.Errorf("Severity = %v; want structural", f.Severity)
+	}
+	if f.Location.Slot != 2 || f.Location.Filename != "stub" {
+		t.Errorf("Location fields wrong; got %+v", f.Location)
+	}
+	if f.Message == "" || f.Citation == "" {
+		t.Errorf("Message and Citation should be populated")
+	}
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -139,3 +139,22 @@ func TestRegisterRejectsDuplicateID(t *testing.T) {
 	}()
 	Register(Rule{ID: "DUP", Severity: SeverityFatal, Description: "y", Citation: "x:2"})
 }
+
+func TestCheckContextShape(t *testing.T) {
+	di := NewDiskImage()
+	dj := di.DiskJournal()
+	ctx := &CheckContext{
+		Disk:    di,
+		Journal: dj,
+		Dialect: DialectSAMDOS2,
+	}
+	if ctx.Disk != di {
+		t.Errorf("ctx.Disk wrong")
+	}
+	if ctx.Journal != dj {
+		t.Errorf("ctx.Journal wrong")
+	}
+	if ctx.Dialect != DialectSAMDOS2 {
+		t.Errorf("ctx.Dialect = %v; want samdos2", ctx.Dialect)
+	}
+}

--- a/verify_test.go
+++ b/verify_test.go
@@ -46,3 +46,40 @@ func TestDialectString(t *testing.T) {
 		}
 	}
 }
+
+func TestLocationDiskWide(t *testing.T) {
+	loc := DiskWideLocation()
+	if !loc.IsDiskWide() {
+		t.Errorf("DiskWideLocation().IsDiskWide() = false; want true")
+	}
+	if loc.Slot != -1 || loc.Sector != nil || loc.ByteOffset != -1 || loc.Filename != "" {
+		t.Errorf("DiskWideLocation() should leave all fields unset; got %+v", loc)
+	}
+}
+
+func TestLocationSlot(t *testing.T) {
+	loc := SlotLocation(3, "IN")
+	if loc.IsDiskWide() {
+		t.Errorf("SlotLocation(3).IsDiskWide() = true; want false")
+	}
+	if loc.Slot != 3 {
+		t.Errorf("Slot = %d; want 3", loc.Slot)
+	}
+	if loc.Filename != "IN" {
+		t.Errorf("Filename = %q; want %q", loc.Filename, "IN")
+	}
+	if loc.Sector != nil || loc.ByteOffset != -1 {
+		t.Errorf("SlotLocation should leave sector + byte unset; got %+v", loc)
+	}
+}
+
+func TestLocationSector(t *testing.T) {
+	sec := &Sector{Track: 6, Sector: 3}
+	loc := SectorLocation(2, "stub", sec, 8)
+	if loc.IsDiskWide() {
+		t.Errorf("SectorLocation.IsDiskWide() = true; want false")
+	}
+	if loc.Slot != 2 || loc.Filename != "stub" || loc.Sector != sec || loc.ByteOffset != 8 {
+		t.Errorf("SectorLocation fields wrong; got %+v", loc)
+	}
+}


### PR DESCRIPTION
First of six implementation phases for the `samfile verify` feature designed in `docs/specs/2026-05-11-verify-feature-design.md`. Foundation only — no real rule implementations.

## What's in

- **Type system** in `verify.go`: `Severity`, `Dialect`, `Location` (with `DiskWideLocation` / `SlotLocation` / `SectorLocation` factories), `Finding`, `Rule`, `CheckContext`, `VerifyReport`, `FilterOpts`.
- **Package-private rule registry**: `Register` (panics on duplicate ID at init time), `Rules()` (returns defensive copy).
- **`(*DiskImage).Verify()`** entry point — runs every registered rule whose `Dialects` matches the detected dialect (Phase 1 always passes `DialectUnknown`; `DetectDialect` lands in Phase 2). Returns a `VerifyReport`; never returns an error (rule failures are `Finding`s, not errors).
- **One smoke-test rule** `DISK-NOT-EMPTY` in `rules_smoke.go` — seeds the `rules_<category>.go` convention phases 3-6 will follow.
- **CLI subcommand** `samfile verify -i FILE` wired through `cmd/samfile/{main.go,usage.go,verify.go}`. Default verbose human output; exit 0 unless a fatal finding fires.

## Definition of Done (from `docs/plans/2026-05-11-verify-phase-1-foundation.md`)

- [x] `go test -count=1 ./...` passes
- [x] `samfile verify -i <empty.mgt>` prints a `DISK-NOT-EMPTY` finding under `INCONSISTENCY (1):`, exits 0
- [x] `samfile verify -i <populated.mgt>` prints `no findings.`, exits 0
- [x] `samfile -h` lists `verify`
- [x] `(*samfile.DiskImage).Verify()` callable from external Go packages

End-to-end binary check, populated disk:
```
samfile verify: results for pop.mgt
detected dialect: unknown

no findings.
```

Empty disk:
```
samfile verify: results for empty.mgt
detected dialect: unknown

INCONSISTENCY (1):
  [DISK-NOT-EMPTY]
    disk has 0 occupied directory entries (all 80 slots are free)
    citation: docs/disk-validity-rules.md

1 finding(s).
```

## Commit structure

12 commits — 10 TDD tasks (one per plan task, each: failing test → run/expect fail → minimal impl → run/expect pass → commit) + 2 polish commits at the end. Reviewable as small atomic steps.

Plan: `docs/plans/2026-05-11-verify-phase-1-foundation.md` (already on `master` via PR #14).

## Out of scope (deferred to later phases)

- **`DetectDialect`** heuristic — Phase 2.
- **The other 70 rules** from `docs/disk-validity-rules.md` — Phases 3-6.
- **CLI flags** `--severity` / `--all` / `--rule` / `--dialect` / `--json` / `--quiet` — added when rule volume justifies them.
- **Testdata corpus in `testdata/mgt/`** — added when the first real rule needs realistic fixtures.

## Known limitation worth flagging

`TestVerifyCmdOnFatalFinding` (the polish-commit test covering the fatal → non-nil-error path) registers a synthetic fatal rule but has to gate the Check on a marker filename (`FATAL-MARK*`) so it doesn't poison sibling tests in the same `go test` process. This is because the registry is package-private with no `Unregister`. Phase 2+ might want to add `Unregister` (or a `TestMain`-scoped registry snapshot helper) — corpus-validation tests will hit the same limitation when they want a fully-clean registry per case.

## Test plan

- [x] `go test -count=1 ./...` green
- [x] `go test -count=2 ./cmd/samfile/` green (proves the registry guards work across runs in one process)
- [x] `gofmt -d` on Phase 1 files clean; `go vet ./...` clean
- [x] End-to-end binary exercise on empty + populated disks (output above)
- [ ] CI green on `master`-rebase

## What lands next

Phase 2 plan (write next): `DetectDialect(*DiskImage) Dialect` heuristic — sniffs the disk for SAMDOS 2 / MasterDOS / SAMDOS 1 signatures and tags the report so dialect-scoped rules in phases 3-6 can actually fire.