### PR TITLE
verify: Phase 4 — body-header & FT_CODE rules (15 rules)

### DIFF
--- a/docs/plans/2026-05-12-verify-phase-4-body-header-ftcode.md
+++ b/docs/plans/2026-05-12-verify-phase-4-body-header-ftcode.md
@@ -1,0 +1,1205 @@
+# Verify Phase 4 — Body-Header & FT_CODE Rules
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement 15 of the catalog's §5 (body-header consistency) and §6 (FT_CODE-specific) rules. After this lands the registry holds 35 rules total (Phase-1 smoke + 19 Phase-3 + 15 Phase-4); file-type-specific rules for BASIC/array/screen/snapshot follow in Phase 5.
+
+**Architecture:** Two new files per the Phase 3 convention — `rules_body_header.go` and `rules_ft_code.go`. A small private helper `bodyHeaderRaw(*DiskImage, *FileEntry) ([9]byte, error)` reads the 9-byte body header at a file's first sector once per rule; rules don't reach into `SectorData` directly. The §5 byte-mirror rules share a tiny `bodyDirMirrorFinding` helper to DRY the "body byte vs dir field" comparison without sacrificing per-rule citations or severities. §6 rules filter on `fe.Type == FT_CODE` at the top of each Check function — no new helper, four rules don't justify one.
+
+**Tech Stack:** Go 1.22+, standard library only. Existing `samfile` API (`DiskJournal`, `FileEntry`, `SectorData`, `FT_CODE`, `FileEntry.Start()`, `FileEntry.Length()`).
+
+**Context for the engineer:**
+
+Read these first, in order:
+
+1. `docs/specs/2026-05-11-verify-feature-design.md` §"Implementation order" Phase 4: "~16 rules. Includes the two PR-12-confirmed mirrors (BODY-EXEC-DIV16K-MATCHES-DIR and BODY-EXEC-MOD16K-LO-MATCHES-DIR) as the simplest demonstrations."
+2. `docs/disk-validity-rules.md` §0 (PR-12 hypotheses verified), §5 (Body-header rules), §6 (FT_CODE rules). §0 is the authoritative source for "what bytes mirror what" — re-read it before each mirror rule.
+3. `samfile.go:80-217` — `FileEntry` struct (dir-field accessors), `FileHeader` struct (parsed body-header), `samfile.go:756-766` (how `samfile.File` reconstructs FileHeader from raw bytes — your `bodyHeaderRaw` does just the byte-read half).
+4. `rules_directory.go` from Phase 3 — the `forEachUsedSlot` helper you'll use throughout, plus the per-rule pattern (`init()` + `Register(Rule{...})` + `checkXxx(ctx)` function).
+5. `rules_chain.go` from Phase 3 — `walkChain` is unrelated here but its shape (private helper file-local; Result struct; documented error path) is the precedent for `bodyHeaderRaw`.
+
+**Phase 4 scope: 15 rules.** The catalog has 17 entries across §5 + §6; two are deliberately deferred:
+
+| Catalog rule | Phase 4 status |
+|---|---|
+| BODY-HEADER-AT-FIRST-SECTOR | DEFER — parser invariant. `samfile.File` and any consumer reading the first 9 bytes of `FirstSector` treats them AS the body header by definition. No falsifiable check at Verify time. |
+| CODE-EXEC-FF-DISABLES | DEFER — documents behaviour, not a check. The catalog says "no further check needed on 0xF3-0xF4" when `dir[0xF2]==0xFF`. There's nothing to assert; it's a `LOAD CODE` semantics fact. |
+
+The 15 rules **in scope** (3 + 5 + 3 + 4 = 15):
+
+**§5 byte-mirror rules** (5 — single-byte body vs dir):
+- BODY-TYPE-MATCHES-DIR
+- BODY-EXEC-DIV16K-MATCHES-DIR
+- BODY-EXEC-MOD16K-LO-MATCHES-DIR
+- BODY-PAGES-MATCHES-DIR
+- BODY-STARTPAGE-MATCHES-DIR
+
+**§5 multi-byte mirror rules** (3):
+- BODY-LENGTHMOD16K-MATCHES-DIR (2 bytes)
+- BODY-PAGEOFFSET-MATCHES-DIR (2 bytes)
+- BODY-MIRROR-AT-DIR-D3-DB (verify dir[0xD2]==0 and dir[0xD3..0xDB] equals body[0..8])
+
+**§5 format rules** (3):
+- BODY-PAGEOFFSET-8000H-FORM (cosmetic — bit 15 of PageOffset is set)
+- BODY-PAGE-LE-31 (structural — `body[8] & 0x1F` is in 0..30; index 31 would point off-disk after `+1`)
+- BODY-BYTES-5-6-CANONICAL-FF (cosmetic — when `body[5]==0xFF`, `body[6]==0xFF` too)
+
+**§6 FT_CODE rules** (4):
+- CODE-LOAD-ABOVE-ROM (fatal)
+- CODE-LOAD-FITS-IN-MEMORY (fatal)
+- CODE-EXEC-WITHIN-LOADED-RANGE (structural)
+- CODE-FILETYPEINFO-EMPTY (cosmetic)
+
+After Task 5 the registry holds 35 rules total (Phase-1 smoke + 19 Phase-3 + 15 Phase-4).
+
+**Phase 4 standing rules** (same as Phase 3):
+
+- Use `g` (the user's alias) not plain `git` for commits — it preserves authorship timestamps.
+- Every rule's `Citation` field cites a real `file:line` location. Citations are pre-filled in each rule block below; copy them verbatim.
+- Test fabrication uses the inline pattern from Phase 2/3 (`NewDiskImage` + `AddCodeFile` + targeted byte patches via the journal or raw-sector writes).
+- Each rule ships with positive + negative tests.
+- Draft PR only. Push/PR/CI is Task 5.
+
+---
+
+## File Structure
+
+| Path | Action | Responsibility |
+|---|---|---|
+| `rules_body_header.go` | Create | §5 body-header rules: 11 rules + the `bodyHeaderRaw` helper + `bodyDirMirrorFinding` helper. |
+| `rules_body_header_test.go` | Create | Positive + negative tests for §5 rules (22 tests). |
+| `rules_ft_code.go` | Create | §6 FT_CODE rules: 4 rules. No new helper. |
+| `rules_ft_code_test.go` | Create | Positive + negative tests for §6 rules (8 tests). |
+| `rules_smoke_test.go` | Modify | Update `TestPhase3RegistryGrowth` → `TestRegistryGrowth` (or similar) with new count 35. |
+
+---
+
+## The body-header read helper
+
+Add at the top of `rules_body_header.go`:
+
+```go
+package samfile
+
+import "fmt"
+
+// bodyHeaderRaw reads the 9 leading bytes of fe's body — the on-disk
+// FileHeader bytes (Type, LengthMod16K-lo, LengthMod16K-hi, PageOffset-lo,
+// PageOffset-hi, ExecutionAddressDiv16K, ExecutionAddressMod16KLo, Pages,
+// StartPage). Returns an error if fe.FirstSector is unreadable; rules
+// should treat that as "no finding" because §1 / §2 rules already report
+// the underlying first-sector problem.
+//
+// This is a thin convenience over SectorData(fe.FirstSector); it does
+// not allocate beyond the returned array.
+func bodyHeaderRaw(di *DiskImage, fe *FileEntry) ([9]byte, error) {
+	var hdr [9]byte
+	sd, err := di.SectorData(fe.FirstSector)
+	if err != nil {
+		return hdr, err
+	}
+	copy(hdr[:], sd[:9])
+	return hdr, nil
+}
+
+// bodyDirMirrorFinding compares one expected (dir-derived) value to one
+// actual (body-derived) value and returns either nil or a single Finding
+// pinpointing the mismatch. The same shape is used by every §5 byte-mirror
+// rule — RuleID, Severity, Citation, and a human-readable fieldName feed
+// into a uniform message format.
+func bodyDirMirrorFinding(
+	ruleID string, sev Severity, citation, fieldName string,
+	slot int, name string,
+	expected, actual uint8,
+) []Finding {
+	if expected == actual {
+		return nil
+	}
+	return []Finding{{
+		RuleID:   ruleID,
+		Severity: sev,
+		Location: SlotLocation(slot, name),
+		Message:  fmt.Sprintf("body %s = 0x%02x but dir says 0x%02x", fieldName, actual, expected),
+		Citation: citation,
+	}}
+}
+```
+
+The helpers' shape is shared by every §5 rule in Tasks 2 and 3. Read them once; the per-rule Check functions then collapse to ~8 lines.
+
+---
+
+## Task 1: Skeleton + registry-growth gate update
+
+**Why this task exists:** lock in the two new files and update the registry-growth assertion before any rule lands. Phase 3's gate was `len(Rules()) == 20`; Phase 4 grows it to 35. The plan keeps it on the existing `TestPhase3RegistryGrowth` name (it's a "current expected count" gate, not phase-specific in intent); renaming is opportunistic cleanup.
+
+**Files:**
+- Create: `rules_body_header.go`, `rules_ft_code.go` (skeletons).
+- Modify: `rules_smoke_test.go` (rename test, update count to 35).
+
+- [ ] **Step 1: Create the rule-file skeletons with their helper(s)**
+
+Create `rules_body_header.go` with the package decl, the section comment, AND the two helpers above (`bodyHeaderRaw`, `bodyDirMirrorFinding`). The helpers don't depend on any rule, so they land in Task 1 to keep Task 2's diff focused on rules.
+
+```go
+// rules_body_header.go
+package samfile
+
+import "fmt"
+
+// §5 Body-header rules (catalog docs/disk-validity-rules.md §5).
+// Rules in this file compare the 9-byte body header at each used
+// file's first sector against the parsed directory-entry fields it
+// is supposed to mirror, plus a handful of byte-level format
+// invariants that don't have a dir-entry counterpart. They apply to
+// all dialects.
+//
+// bodyHeaderRaw (private) reads the 9-byte header once per rule
+// invocation; bodyDirMirrorFinding (private) standardises the
+// "body field X mismatches dir field Y" Finding shape.
+
+// ...bodyHeaderRaw and bodyDirMirrorFinding declarations as above...
+```
+
+Create `rules_ft_code.go`:
+
+```go
+// rules_ft_code.go
+package samfile
+
+import "fmt"
+
+// §6 FT_CODE rules (catalog docs/disk-validity-rules.md §6).
+// Rules in this file check FT_CODE-specific invariants: the file's
+// load address is above ROM, the loaded region fits in SAM's 512 KiB
+// address space, the execution address (if not opted out) lies within
+// the loaded region, and dir-entry FileTypeInfo is unused (cosmetic).
+// Each Check function filters on fe.Type == FT_CODE at the top.
+```
+
+- [ ] **Step 2: Rename + update the registry-growth gate**
+
+In `rules_smoke_test.go`, find `TestPhase3RegistryGrowth` and rename it to `TestRegistryGrowth`. Update the assertion:
+
+```go
+// TestRegistryGrowth pins the expected total rule count. Update when
+// new rules are added or removed so the test surfaces accidental
+// changes to the registry size.
+func TestRegistryGrowth(t *testing.T) {
+	if got := len(Rules()); got != 35 {
+		t.Errorf("len(Rules()) = %d; want 35 (1 smoke + 19 phase-3 + 15 phase-4 rules)", got)
+	}
+}
+```
+
+- [ ] **Step 3: Verify skeleton compiles + test fails as expected**
+
+```
+cd /Users/pmoore/git/samfile-verify-phase-4 && go build ./...
+```
+Expected: silent, exit 0.
+
+```
+cd /Users/pmoore/git/samfile-verify-phase-4 && go test -run TestRegistryGrowth -v ./...
+```
+Expected: FAIL with `len(Rules()) = 20; want 35` (Phase-3's 20 rules are present; Phase-4's 15 haven't landed yet).
+
+Other tests should still pass:
+
+```
+cd /Users/pmoore/git/samfile-verify-phase-4 && go test ./...
+```
+Expected: only `TestRegistryGrowth` fails.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/pmoore/git/samfile-verify-phase-4 && \
+g add rules_body_header.go rules_ft_code.go rules_smoke_test.go && \
+g commit -m "verify: phase 4 skeleton (body-header + FT_CODE files + helpers)
+
+Two new rule-file skeletons for §5 and §6 of the catalog, plus
+two private helpers in rules_body_header.go:
+
+  bodyHeaderRaw(di, fe)       — read the 9-byte body header
+  bodyDirMirrorFinding(...)   — uniform finding shape for the
+                                §5 byte-mirror rules
+
+TestPhase3RegistryGrowth is renamed TestRegistryGrowth and the
+count gate bumps from 20 to 35 (1 smoke + 19 phase-3 + 15
+phase-4 rules). The test deliberately fails after this commit;
+it turns green once Tasks 2-4 register the remaining rules."
+```
+
+---
+
+## Task 2: §5 byte-mirror rules (8 rules — 5 single-byte + 3 multi-byte)
+
+**Why this task exists:** the 8 mirror rules are the heart of §5 — every one of them checks "body bytes X..Y equal dir bytes Z..W". Doing them together exercises the `bodyHeaderRaw` + `bodyDirMirrorFinding` helpers in one coherent commit.
+
+**Files:**
+- Modify: `rules_body_header.go` — register and implement 8 rules.
+- Modify: `rules_body_header_test.go` — create, with two tests per rule (16 tests).
+
+### The 5 single-byte mirror rules
+
+For each rule below, paste this block, substituting the parameters. The Check function shape is identical; only the parameters change.
+
+```go
+func init() {
+	Register(Rule{
+		ID:          "<RULE-ID>",
+		Severity:    Severity<X>,
+		Description: "<one-line>",
+		Citation:    "<file:line>",
+		Check:       check<RuleName>,
+	})
+}
+
+func check<RuleName>(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return // §1 rules already report the underlying first-sector problem
+		}
+		findings = append(findings, bodyDirMirrorFinding(
+			"<RULE-ID>", Severity<X>, "<file:line>", "<fieldName>",
+			slot, fe.Name.String(),
+			<expected from dir-entry field>, hdr[<index>],
+		)...)
+	})
+	return findings
+}
+```
+
+The 5 single-byte rules:
+
+| Rule ID | Severity | Body index | Dir-field expected | fieldName | Citation |
+|---|---|---|---|---|---|
+| `BODY-TYPE-MATCHES-DIR` | `SeverityInconsistency` | `hdr[0]` | `uint8(fe.Type) & 0x1F` | `"type"` | `samdos/src/c.s:1395-1408` |
+| `BODY-EXEC-DIV16K-MATCHES-DIR` | `SeverityStructural` | `hdr[5]` | `fe.ExecutionAddressDiv16K` | `"ExecutionAddressDiv16K"` | `rom-disasm:22471-22484` |
+| `BODY-EXEC-MOD16K-LO-MATCHES-DIR` | `SeverityInconsistency` | `hdr[6]` | `uint8(fe.ExecutionAddressMod16K & 0xFF)` | `"ExecutionAddressMod16KLo"` | `rom-disasm:22472` |
+| `BODY-PAGES-MATCHES-DIR` | `SeverityInconsistency` | `hdr[7]` | `fe.Pages` | `"Pages"` | `samdos/src/c.s:1376-1379` |
+| `BODY-STARTPAGE-MATCHES-DIR` | `SeverityInconsistency` | `hdr[8]` | `fe.StartAddressPage` | `"StartAddressPage"` | `samdos/src/c.s:1376-1379` |
+
+Note for `BODY-STARTPAGE-MATCHES-DIR`: the catalog (§5 BODY-STARTPAGE-MATCHES-DIR) flags that "only the low 5 bits are functional... bits 5-7 are decorative and may differ between byte-perfect ROM-SAVE output and synthetic writers". For Phase 4 we compare the full byte. Phase 7's corpus pass may demote the severity if real-world disks routinely differ on the decorative bits.
+
+Note for `BODY-TYPE-MATCHES-DIR`: the comparison is `(dir[0] & 0x1F) == body[0]` — both sides have HIDDEN/PROTECTED stripped (samfile's `FileType` raw value is the unmasked byte; body[0] in samfile-generated disks has no attribute bits, so masking dir before comparing is correct).
+
+### The 3 multi-byte mirror rules
+
+`BODY-LENGTHMOD16K-MATCHES-DIR` and `BODY-PAGEOFFSET-MATCHES-DIR` each compare 2 bytes; they don't fit the `bodyDirMirrorFinding` 1-byte helper, so they read directly:
+
+```go
+func init() {
+	Register(Rule{
+		ID:          "BODY-LENGTHMOD16K-MATCHES-DIR",
+		Severity:    SeverityInconsistency,
+		Description: "body header LengthMod16K (bytes 1-2 LE) equals dir-entry LengthMod16K",
+		Citation:    "samdos/src/c.s:1376-1379",
+		Check:       checkBodyLengthMod16KMatchesDir,
+	})
+}
+
+func checkBodyLengthMod16KMatchesDir(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		actual := uint16(hdr[1]) | uint16(hdr[2])<<8
+		if actual != fe.LengthMod16K {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-LENGTHMOD16K-MATCHES-DIR",
+				Severity: SeverityInconsistency,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("body LengthMod16K = 0x%04x but dir says 0x%04x", actual, fe.LengthMod16K),
+				Citation: "samdos/src/c.s:1376-1379",
+			})
+		}
+	})
+	return findings
+}
+```
+
+`BODY-PAGEOFFSET-MATCHES-DIR` is the same shape, swap LengthMod16K → StartAddressPageOffset and body indices 1,2 → 3,4:
+
+```go
+func init() {
+	Register(Rule{
+		ID:          "BODY-PAGEOFFSET-MATCHES-DIR",
+		Severity:    SeverityInconsistency,
+		Description: "body header PageOffset (bytes 3-4 LE) equals dir-entry StartAddressPageOffset",
+		Citation:    "samdos/src/c.s:1376-1379",
+		Check:       checkBodyPageOffsetMatchesDir,
+	})
+}
+
+func checkBodyPageOffsetMatchesDir(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		actual := uint16(hdr[3]) | uint16(hdr[4])<<8
+		if actual != fe.StartAddressPageOffset {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-PAGEOFFSET-MATCHES-DIR",
+				Severity: SeverityInconsistency,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("body PageOffset = 0x%04x but dir says 0x%04x", actual, fe.StartAddressPageOffset),
+				Citation: "samdos/src/c.s:1376-1379",
+			})
+		}
+	})
+	return findings
+}
+```
+
+`BODY-MIRROR-AT-DIR-D3-DB` is a 9-byte mirror plus the dir[0xD2]==0 invariant. The dir bytes 0xD2-0xDB are exposed via `fe.MGTFutureAndPast[0..9]` (10 bytes; [0]=0xD2, [1..9]=0xD3..0xDB):
+
+```go
+func init() {
+	Register(Rule{
+		ID:          "BODY-MIRROR-AT-DIR-D3-DB",
+		Severity:    SeverityInconsistency,
+		Description: "dir bytes 0xD3..0xDB mirror body header bytes 0..8 (and dir byte 0xD2 is 0)",
+		Citation:    "samdos/src/f.s:462-471",
+		Check:       checkBodyMirrorAtDirD3DB,
+	})
+}
+
+func checkBodyMirrorAtDirD3DB(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		// dir byte 0xD2 == 0 (MGTFutureAndPast[0])
+		if fe.MGTFutureAndPast[0] != 0 {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-MIRROR-AT-DIR-D3-DB",
+				Severity: SeverityInconsistency,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("dir byte 0xD2 (MGTFutureAndPast[0]) = 0x%02x but should be 0", fe.MGTFutureAndPast[0]),
+				Citation: "samdos/src/f.s:462-471",
+			})
+		}
+		// dir bytes 0xD3..0xDB (MGTFutureAndPast[1..9]) mirror body bytes 0..8
+		for i := 0; i < 9; i++ {
+			if fe.MGTFutureAndPast[1+i] != hdr[i] {
+				findings = append(findings, Finding{
+					RuleID:   "BODY-MIRROR-AT-DIR-D3-DB",
+					Severity: SeverityInconsistency,
+					Location: SlotLocation(slot, fe.Name.String()),
+					Message:  fmt.Sprintf("dir byte 0x%02x (MGTFutureAndPast[%d]) = 0x%02x but body byte %d = 0x%02x",
+						0xD3+i, 1+i, fe.MGTFutureAndPast[1+i], i, hdr[i]),
+					Citation: "samdos/src/f.s:462-471",
+				})
+				return // one finding per slot is enough; the disagreement is the signal
+			}
+		}
+	})
+	return findings
+}
+```
+
+### Tests
+
+Create `rules_body_header_test.go`. For each rule, two tests (positive: clean disk → 0 findings; negative: mutate one byte → 1 finding).
+
+A shared helper at the top of the file (reusing `cleanSingleFileDisk` from `rules_disk_test.go`):
+
+```go
+package samfile
+
+import "testing"
+
+// mutateFirstSectorByte patches one byte of slot 0's first sector
+// payload (e.g. body header bytes). It's a small utility for the
+// body-header tests' negative cases; raw byte-level mutation is
+// the only way to disturb the body header without re-running the
+// whole AddCodeFile path (which would re-mirror to the dir entry).
+func mutateFirstSectorByte(t *testing.T, di *DiskImage, byteOffset int, newValue byte) {
+	t.Helper()
+	fe := di.DiskJournal()[0]
+	sd, err := di.SectorData(fe.FirstSector)
+	if err != nil {
+		t.Fatalf("SectorData: %v", err)
+	}
+	sd[byteOffset] = newValue
+	di.WriteSector(fe.FirstSector, sd)
+}
+```
+
+A representative test pair (apply for every rule with appropriate field & severity):
+
+```go
+func TestBodyTypeMatchesDirPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyTypeMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyTypeMatchesDirNegative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	// Patch body byte 0 (Type) to a value the dir doesn't reflect.
+	mutateFirstSectorByte(t, di, 0, 0x05) // body says ZX_SNAPSHOT, dir says CODE
+	findings := checkBodyTypeMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-TYPE-MATCHES-DIR" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-TYPE-MATCHES-DIR", len(findings), findings)
+	}
+}
+```
+
+Negative-test byte patches for the remaining 7 rules:
+
+| Rule | Mutation | Notes |
+|---|---|---|
+| `BODY-EXEC-DIV16K-MATCHES-DIR` | `mutateFirstSectorByte(t, di, 5, 0x7E)` | Dir's `ExecutionAddressDiv16K` is 0xFF for `AddCodeFile(..., 0)` (no auto-exec); 0x7E differs. |
+| `BODY-EXEC-MOD16K-LO-MATCHES-DIR` | `mutateFirstSectorByte(t, di, 6, 0xAA)` | Dir's `ExecutionAddressMod16K` low byte is 0xFF for no-exec; 0xAA differs. |
+| `BODY-PAGES-MATCHES-DIR` | `mutateFirstSectorByte(t, di, 7, 0x99)` | Dir's `Pages` for a 100-byte CODE file is 0; 0x99 differs. |
+| `BODY-STARTPAGE-MATCHES-DIR` | `mutateFirstSectorByte(t, di, 8, 0x99)` | Dir's `StartAddressPage` for load 0x8000 is 1; 0x99 differs. |
+| `BODY-LENGTHMOD16K-MATCHES-DIR` | `mutateFirstSectorByte(t, di, 1, 0xAA)` | Patching byte 1 alone disagrees with the dir's parsed 16-bit LengthMod16K. |
+| `BODY-PAGEOFFSET-MATCHES-DIR` | `mutateFirstSectorByte(t, di, 3, 0xAA)` | Same shape, byte 3. |
+| `BODY-MIRROR-AT-DIR-D3-DB` | Patch `dj[0].MGTFutureAndPast[0] = 0xFF` via journal + `WriteFileEntry` | Trip the dir[0xD2]==0 invariant. Alternative for the mirror half: change one of MGTFutureAndPast[1..9] to differ from the corresponding body byte. |
+
+For `BODY-MIRROR-AT-DIR-D3-DB` the negative test patches the journal rather than the sector because the rule's first-byte-of-MGTFutureAndPast check is fastest to trip with the journal:
+
+```go
+func TestBodyMirrorAtDirD3DBNegative(t *testing.T) {
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	dj[0].MGTFutureAndPast[0] = 0xFF
+	di.WriteFileEntry(dj, 0)
+	findings := checkBodyMirrorAtDirD3DB(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-MIRROR-AT-DIR-D3-DB" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-MIRROR-AT-DIR-D3-DB", len(findings), findings)
+	}
+}
+```
+
+- [ ] **Step 1: Implement the 8 mirror rules and 16 tests**
+
+- [ ] **Step 2: Build + run the relevant tests**
+
+```
+cd /Users/pmoore/git/samfile-verify-phase-4 && go build ./... && go test -run 'TestBody' -v ./...
+```
+Expected: 16 PASS (8 positive + 8 negative). No FAIL.
+
+Then run the full suite:
+
+```
+cd /Users/pmoore/git/samfile-verify-phase-4 && go test ./...
+```
+Expected: all tests pass EXCEPT `TestRegistryGrowth`, which now reports 28 rules instead of 35 (still failing — will turn green at Task 4).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/pmoore/git/samfile-verify-phase-4 && \
+g add rules_body_header.go rules_body_header_test.go && \
+g commit -m "verify: §5 body-header mirror rules (8 rules)
+
+Adds the eight rules that compare each used file's 9-byte body
+header to the directory-entry fields it should mirror:
+
+  BODY-TYPE-MATCHES-DIR             inconsistency  body[0]
+  BODY-LENGTHMOD16K-MATCHES-DIR     inconsistency  body[1..3]
+  BODY-PAGEOFFSET-MATCHES-DIR       inconsistency  body[3..5]
+  BODY-EXEC-DIV16K-MATCHES-DIR      structural     body[5]
+  BODY-EXEC-MOD16K-LO-MATCHES-DIR   inconsistency  body[6]
+  BODY-PAGES-MATCHES-DIR            inconsistency  body[7]
+  BODY-STARTPAGE-MATCHES-DIR        inconsistency  body[8]
+  BODY-MIRROR-AT-DIR-D3-DB          inconsistency  dir[0xD2..0xDB]
+
+The five single-byte rules use the shared bodyDirMirrorFinding
+helper from Task 1 for uniform message formatting. The three
+multi-byte rules read the body header directly and emit one
+finding per first violating byte (per-slot, not per-byte) to
+avoid noise. BODY-EXEC-DIV16K-MATCHES-DIR is the structural-
+severity one because the ROM auto-exec gate (rom-disasm:22471-
+22484) checks both this and dir byte 0xF2 for FF before
+deciding to JP; a mismatch can cause unwanted auto-exec."
+```
+
+---
+
+## Task 3: §5 format rules (3 rules)
+
+**Why this task exists:** these three rules don't have a dir-entry counterpart — they're format invariants on the body header itself. Two are cosmetic (real-SAVE conventions) and one is structural (page-index range check).
+
+**Files:**
+- Modify: `rules_body_header.go` — append 3 rules.
+- Modify: `rules_body_header_test.go` — append 6 tests.
+
+### Rules
+
+```go
+// ----- BODY-PAGEOFFSET-8000H-FORM -----
+// Real ROM SAVE writes PageOffset with bit 15 set ("8000H form" / REL
+// PAGE FORM convention, Tech Manual L3037-3052). Both samfile.Start()
+// and the ROM PDPSR2 decoder mask & 0x3FFF before use, so a bit-15-
+// clear value still parses — but it deviates from convention and is
+// a useful corpus-validation signal.
+func init() {
+	Register(Rule{
+		ID:          "BODY-PAGEOFFSET-8000H-FORM",
+		Severity:    SeverityCosmetic,
+		Description: "body-header PageOffset has bit 15 set (8000H-form convention)",
+		Citation:    "sam-coupe_tech-man_v3-0.txt:3037-3052",
+		Check:       checkBodyPageOffset8000HForm,
+	})
+}
+
+func checkBodyPageOffset8000HForm(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		pageOffset := uint16(hdr[3]) | uint16(hdr[4])<<8
+		// A zero offset is a legitimate "page-aligned" load; only warn
+		// when there are bits in the low 14 but bit 15 is clear.
+		if pageOffset != 0 && pageOffset&0x8000 == 0 {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-PAGEOFFSET-8000H-FORM",
+				Severity: SeverityCosmetic,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("body PageOffset = 0x%04x is missing bit 15 (8000H-form convention)", pageOffset),
+				Citation: "sam-coupe_tech-man_v3-0.txt:3037-3052",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- BODY-PAGE-LE-31 -----
+// body[8] & 0x1F is the page index BEFORE samfile's +1 shift in
+// FileHeader.Start(). Index 31 (raw) gives a +1 of 32, which lands
+// the load address at 0x80000 (off-disk pseudo-page used as a
+// marker, e.g. by SAMBASIC). Real on-disk load addresses use 0..30.
+func init() {
+	Register(Rule{
+		ID:          "BODY-PAGE-LE-31",
+		Severity:    SeverityStructural,
+		Description: "body-header StartPage's low 5 bits encode an on-disk page index (0..30)",
+		Citation:    "samfile.go:248-249",
+		Check:       checkBodyPageLE31,
+	})
+}
+
+func checkBodyPageLE31(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		page := hdr[8] & 0x1F
+		if page > 30 {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-PAGE-LE-31",
+				Severity: SeverityStructural,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("body StartPage low-5 bits = %d (>30); +1 shift lands above on-disk pages", page),
+				Citation: "samfile.go:248-249",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- BODY-BYTES-5-6-CANONICAL-FF -----
+// When ExecutionAddressDiv16K (body[5]) is 0xFF (the "no auto-exec"
+// marker), real ROM SAVE writes 0xFF to body[6] as well — both bytes
+// 0xFF are the canonical "no auto-exec" pair. samfile's writer emits
+// 0x00 for body[6] in that case (samfile.go:1011-1023). Both parse
+// identically, but the convention is FF FF.
+func init() {
+	Register(Rule{
+		ID:          "BODY-BYTES-5-6-CANONICAL-FF",
+		Severity:    SeverityCosmetic,
+		Description: "when body[5]==0xFF (no auto-exec), real SAVE writes body[6]==0xFF too",
+		Citation:    "rom-disasm:22076-22080",
+		Check:       checkBodyBytes56CanonicalFF,
+	})
+}
+
+func checkBodyBytes56CanonicalFF(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		if hdr[5] == 0xFF && hdr[6] != 0xFF {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-BYTES-5-6-CANONICAL-FF",
+				Severity: SeverityCosmetic,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("body[5]=0xFF (no auto-exec) but body[6]=0x%02x; canonical SAVE writes 0xFF here too", hdr[6]),
+				Citation: "rom-disasm:22076-22080",
+			})
+		}
+	})
+	return findings
+}
+```
+
+### Tests
+
+For each rule, positive + negative pair. The patterns:
+
+```go
+func TestBodyPageOffset8000HFormPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyPageOffset8000HForm(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyPageOffset8000HFormNegative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	// Patch body bytes 3-4 to a non-zero offset with bit 15 clear (0x12 0x34 = 0x3412).
+	mutateFirstSectorByte(t, di, 3, 0x12)
+	mutateFirstSectorByte(t, di, 4, 0x34)
+	findings := checkBodyPageOffset8000HForm(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-PAGEOFFSET-8000H-FORM" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-PAGEOFFSET-8000H-FORM", len(findings), findings)
+	}
+}
+
+func TestBodyPageLE31Positive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyPageLE31(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyPageLE31Negative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	mutateFirstSectorByte(t, di, 8, 0x1F) // low-5 = 31, exceeds 30
+	findings := checkBodyPageLE31(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-PAGE-LE-31" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-PAGE-LE-31", len(findings), findings)
+	}
+}
+
+func TestBodyBytes56CanonicalFFPositive(t *testing.T) {
+	// samfile's AddCodeFile(...,exec=0) sets fe.ExecutionAddressDiv16K = 0xFF
+	// and fe.ExecutionAddressMod16K = 0xFFFF; CreateHeader (samfile.go:921)
+	// in turn emits body[5]=0xFF, body[6]=0xFF — the canonical pair this
+	// rule expects. A clean disk therefore yields no findings.
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyBytes56CanonicalFF(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("clean no-auto-exec disk (body[5..6]={0xFF, 0xFF}): %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyBytes56CanonicalFFNegative(t *testing.T) {
+	// Patch body[6] alone to 0x00, leaving body[5]=0xFF. The {0xFF, 0x00}
+	// pair is the non-canonical mix this cosmetic rule warns about.
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	mutateFirstSectorByte(t, di, 6, 0x00)
+	findings := checkBodyBytes56CanonicalFF(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-BYTES-5-6-CANONICAL-FF" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-BYTES-5-6-CANONICAL-FF", len(findings), findings)
+	}
+}
+```
+
+Note on samfile's actual writer behaviour: the catalog (`BODY-BYTES-5-6-CANONICAL-FF`) cites `samfile.go:1011-1023` as emitting `{0x00, 0x00}` for no-auto-exec CODE files. That was true historically; the current `CreateHeader` at `samfile.go:921-937` defaults both bytes to `0xFF`. So clean samfile-built disks no longer trip this rule.
+
+⚠️ This means `BODY-BYTES-5-6-CANONICAL-FF` only fires when body bytes 5-6 are individually mutated (negative test above) or on legacy/synthetic disks that pre-date the `CreateHeader` fix. The catalog should be updated in a follow-up; that's out of scope for this PR.
+
+- [ ] **Step 1: Append the 3 rules + 6 tests**
+
+- [ ] **Step 2: Build + run**
+
+```
+cd /Users/pmoore/git/samfile-verify-phase-4 && go test -run 'TestBody' -v ./...
+```
+Expected: 22 PASS total (16 from Task 2 + 6 from Task 3).
+
+Then the full suite:
+
+```
+cd /Users/pmoore/git/samfile-verify-phase-4 && go test ./...
+```
+Expected: all tests pass EXCEPT `TestRegistryGrowth` (now 31 rules; want 35).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/pmoore/git/samfile-verify-phase-4 && \
+g add rules_body_header.go rules_body_header_test.go && \
+g commit -m "verify: §5 body-header format rules (3 rules)
+
+Three rules with no dir-entry counterpart — format invariants
+on the body header itself:
+
+  BODY-PAGEOFFSET-8000H-FORM   cosmetic    bit 15 of PageOffset set
+  BODY-PAGE-LE-31              structural  StartPage low-5 ≤ 30
+  BODY-BYTES-5-6-CANONICAL-FF  cosmetic    {0xFF, 0xFF} not {0xFF, 0x00}
+
+BODY-BYTES-5-6-CANONICAL-FF flags every samfile-built CODE file
+that opts out of auto-exec; samfile's writer emits {0xFF, 0x00}
+while ROM SAVE writes {0xFF, 0xFF}. Cosmetic because both parse
+to 'no auto-exec'; Phase 7's corpus pass may decide whether to
+keep the warning."
+```
+
+---
+
+## Task 4: §6 FT_CODE rules (4 rules)
+
+**Why this task exists:** §6 rules apply only to files of type FT_CODE. They check load-address and execution-address invariants that samfile's `AddCodeFile` already validates at SAVE time — but a corrupted disk could have a CODE file whose dir-entry says an out-of-range load address.
+
+**Files:**
+- Modify: `rules_ft_code.go` — register and implement 4 rules.
+- Modify: `rules_ft_code_test.go` — create, with 8 tests.
+
+### Rules
+
+```go
+// ----- CODE-LOAD-ABOVE-ROM -----
+func init() {
+	Register(Rule{
+		ID:          "CODE-LOAD-ABOVE-ROM",
+		Severity:    SeverityFatal,
+		Description: "FT_CODE file's load address is at least 0x4000 (above ROM)",
+		Citation:    "samfile.go:799-801",
+		Check:       checkCodeLoadAboveROM,
+	})
+}
+
+func checkCodeLoadAboveROM(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		if fe.Type != FT_CODE {
+			return
+		}
+		loadAddr := fe.StartAddress()
+		if loadAddr < 0x4000 {
+			findings = append(findings, Finding{
+				RuleID:   "CODE-LOAD-ABOVE-ROM",
+				Severity: SeverityFatal,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("CODE load address 0x%05x is below 0x4000 (ROM)", loadAddr),
+				Citation: "samfile.go:799-801",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- CODE-LOAD-FITS-IN-MEMORY -----
+func init() {
+	Register(Rule{
+		ID:          "CODE-LOAD-FITS-IN-MEMORY",
+		Severity:    SeverityFatal,
+		Description: "FT_CODE file's load address + body length does not exceed SAM's 512 KiB address space",
+		Citation:    "samfile.go:802-804",
+		Check:       checkCodeLoadFitsInMemory,
+	})
+}
+
+func checkCodeLoadFitsInMemory(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		if fe.Type != FT_CODE {
+			return
+		}
+		loadAddr := fe.StartAddress()
+		length := fe.Length()
+		if uint64(loadAddr)+uint64(length) > 0x80000 {
+			findings = append(findings, Finding{
+				RuleID:   "CODE-LOAD-FITS-IN-MEMORY",
+				Severity: SeverityFatal,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("CODE load 0x%05x + length 0x%05x = 0x%05x exceeds SAM's 512 KiB address space",
+					loadAddr, length, uint64(loadAddr)+uint64(length)),
+				Citation: "samfile.go:802-804",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- CODE-EXEC-WITHIN-LOADED-RANGE -----
+func init() {
+	Register(Rule{
+		ID:          "CODE-EXEC-WITHIN-LOADED-RANGE",
+		Severity:    SeverityStructural,
+		Description: "FT_CODE file's execution address (when not 0xFF-disabled) lies within its loaded region",
+		Citation:    "samfile.go:805-810",
+		Check:       checkCodeExecWithinLoadedRange,
+	})
+}
+
+func checkCodeExecWithinLoadedRange(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		if fe.Type != FT_CODE {
+			return
+		}
+		if fe.ExecutionAddressDiv16K == 0xFF {
+			return // 0xFF marker = no auto-exec; nothing to validate
+		}
+		execAddr := fe.ExecutionAddress()
+		loadAddr := fe.StartAddress()
+		length := fe.Length()
+		if execAddr < loadAddr || execAddr >= loadAddr+length {
+			findings = append(findings, Finding{
+				RuleID:   "CODE-EXEC-WITHIN-LOADED-RANGE",
+				Severity: SeverityStructural,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("CODE exec address 0x%05x is outside loaded region [0x%05x, 0x%05x)",
+					execAddr, loadAddr, loadAddr+length),
+				Citation: "samfile.go:805-810",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- CODE-FILETYPEINFO-EMPTY -----
+func init() {
+	Register(Rule{
+		ID:          "CODE-FILETYPEINFO-EMPTY",
+		Severity:    SeverityCosmetic,
+		Description: "FT_CODE file's FileTypeInfo (dir 0xDD-0xE7) is all zero (samfile convention)",
+		Citation:    "samfile.go:798-827",
+		Check:       checkCodeFileTypeInfoEmpty,
+	})
+}
+
+func checkCodeFileTypeInfoEmpty(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		if fe.Type != FT_CODE {
+			return
+		}
+		for _, b := range fe.FileTypeInfo {
+			if b != 0 {
+				findings = append(findings, Finding{
+					RuleID:   "CODE-FILETYPEINFO-EMPTY",
+					Severity: SeverityCosmetic,
+					Location: SlotLocation(slot, fe.Name.String()),
+					Message:  "CODE file has non-zero FileTypeInfo (dir 0xDD-0xE7) — samfile leaves these zero",
+					Citation: "samfile.go:798-827",
+				})
+				return // one finding per slot
+			}
+		}
+	})
+	return findings
+}
+```
+
+### Tests
+
+```go
+package samfile
+
+import "testing"
+
+func TestCodeLoadAboveROMPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100) // load 0x8000
+	findings := checkCodeLoadAboveROM(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("clean CODE file at 0x8000: %d findings; want 0", len(findings))
+	}
+}
+
+func TestCodeLoadAboveROMNegative(t *testing.T) {
+	// AddCodeFile rejects load < 0x4000 (samfile.go:799-801), so we
+	// can't build a violating file via the public API. Patch the
+	// dir entry directly to point below ROM.
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	dj[0].StartAddressPage = 0      // page index 0 → +1 = 1 → 0x4000
+	dj[0].StartAddressPageOffset = 0 // → final load 0x4000
+	// Subtract 1 to land at 0x3FFF (below ROM boundary).
+	// Decoded Start() = ((StartPage & 0x1F)+1)<<14 | (PageOffset & 0x3FFF).
+	// We need < 0x4000, so the (+1)<<14 path with StartPage=0 always
+	// gives 0x4000. We need an off-by-one: set StartPage to a value
+	// that, after +1 shift, produces 0x3FFF or below. The only way is
+	// for the formula's & 0x3FFF mask of PageOffset to interact with
+	// (page+1)<<14 — which it can't, since the mask isolates bits.
+	//
+	// Conclusion: samfile.Start()'s +1 shift makes load < 0x4000
+	// unreachable via legal field values. This rule will never fire
+	// on a samfile-parsed disk. Skip the negative test and document.
+	t.Skip("samfile.Start()'s +1 shift makes Start()<0x4000 unreachable via FileEntry fields; rule is documentation-only and exists for parity with the catalog")
+	_ = di
+}
+
+func TestCodeLoadFitsInMemoryPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkCodeLoadFitsInMemory(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("100-byte file at 0x8000: %d findings; want 0", len(findings))
+	}
+}
+
+func TestCodeLoadFitsInMemoryNegative(t *testing.T) {
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	// Patch Pages to 31 (the off-disk pseudo-page marker via samfile's +1)
+	// so length decodes huge AND the load address is near the top of RAM.
+	dj[0].Pages = 31           // length = 31 * 16384 + (LengthMod16K & 0x3FFF)
+	dj[0].LengthMod16K = 0x3FFF // max bits in low 14 bits
+	di.WriteFileEntry(dj, 0)
+	findings := checkCodeLoadFitsInMemory(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "CODE-LOAD-FITS-IN-MEMORY" {
+		t.Fatalf("got %d findings, first=%+v; want 1 CODE-LOAD-FITS-IN-MEMORY", len(findings), findings)
+	}
+}
+
+func TestCodeExecWithinLoadedRangePositive(t *testing.T) {
+	di := NewDiskImage()
+	if err := di.AddCodeFile("TEST", make([]byte, 100), 0x8000, 0x8010); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+	findings := checkCodeExecWithinLoadedRange(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("exec 0x8010 inside [0x8000, 0x8064): %d findings; want 0", len(findings))
+	}
+}
+
+func TestCodeExecWithinLoadedRangeNegative(t *testing.T) {
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	// Set a real exec address (clear the 0xFF marker), but place it
+	// far outside the loaded region [0x8000, 0x8064).
+	dj[0].ExecutionAddressDiv16K = 0x05      // page 5 = 0x14000
+	dj[0].ExecutionAddressMod16K = 0x8000    // offset 0 (PageOffset form)
+	di.WriteFileEntry(dj, 0)
+	findings := checkCodeExecWithinLoadedRange(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "CODE-EXEC-WITHIN-LOADED-RANGE" {
+		t.Fatalf("got %d findings, first=%+v; want 1 CODE-EXEC-WITHIN-LOADED-RANGE", len(findings), findings)
+	}
+}
+
+func TestCodeFileTypeInfoEmptyPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkCodeFileTypeInfoEmpty(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestCodeFileTypeInfoEmptyNegative(t *testing.T) {
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	dj[0].FileTypeInfo[5] = 0xAA
+	di.WriteFileEntry(dj, 0)
+	findings := checkCodeFileTypeInfoEmpty(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "CODE-FILETYPEINFO-EMPTY" {
+		t.Fatalf("got %d findings, first=%+v; want 1 CODE-FILETYPEINFO-EMPTY", len(findings), findings)
+	}
+}
+```
+
+`TestCodeLoadAboveROMNegative` is skipped because `FileHeader.Start()`'s formula makes Start()<0x4000 unreachable via any FileEntry field combination. The rule itself is correct and matches the catalog; it just can't be exercised through samfile's parse path. Future raw-byte-construction tests (Phase 7+) might exercise it.
+
+- [ ] **Step 1: Implement the 4 rules + 8 tests**
+
+- [ ] **Step 2: Build + run**
+
+```
+cd /Users/pmoore/git/samfile-verify-phase-4 && go test ./...
+```
+Expected: all tests pass INCLUDING `TestRegistryGrowth` (now 35 rules — matches gate).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /Users/pmoore/git/samfile-verify-phase-4 && \
+g add rules_ft_code.go rules_ft_code_test.go && \
+g commit -m "verify: §6 FT_CODE rules (4 rules)
+
+Adds four rules specific to FT_CODE (=19) files:
+
+  CODE-LOAD-ABOVE-ROM            fatal       load >= 0x4000
+  CODE-LOAD-FITS-IN-MEMORY       fatal       load+length <= 0x80000
+  CODE-EXEC-WITHIN-LOADED-RANGE  structural  exec in [load, load+length)
+  CODE-FILETYPEINFO-EMPTY        cosmetic    dir 0xDD-0xE7 all zero
+
+Each Check function filters on fe.Type == FT_CODE at the top;
+no new helper for four rules. CODE-LOAD-ABOVE-ROM has no
+negative-test path because samfile.Start()'s +1 shift makes
+Start()<0x4000 unreachable from any legal FileEntry field
+combination; the test is t.Skip'd with a documentation comment.
+
+TestRegistryGrowth now passes (35 rules registered)."
+```
+
+---
+
+## Task 5: Final verification + push + draft PR + monitor CI
+
+**Why this task exists:** the gate before opening the PR. Run unit tests + vet, smoke the CLI against the corpus and M0 disk, push, open the PR (draft), watch CI.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Full suite + vet**
+
+```
+cd /Users/pmoore/git/samfile-verify-phase-4 && go test ./... && go vet ./...
+```
+Expected: all green, vet silent.
+
+- [ ] **Step 2: Build the CLI**
+
+```
+cd /Users/pmoore/git/samfile-verify-phase-4 && go build -o /tmp/samfile-phase4 ./cmd/samfile
+```
+
+- [ ] **Step 3: Run verify on the corpus image**
+
+```
+/tmp/samfile-phase4 verify -i /Users/pmoore/git/samfile-verify-phase-4/testdata/ETrackerv1.2.mgt 2>/dev/null | grep -E '^[A-Z]+ \(' && echo "---" && /tmp/samfile-phase4 verify -i /Users/pmoore/git/samfile-verify-phase-4/testdata/ETrackerv1.2.mgt 2>/dev/null | tail -3
+```
+Expected: each severity header + a final "N findings" line. Compare with the Phase 3 baseline (350 findings on this disk): Phase 4 should report MORE findings because the new rules fire too. Check the increase is reasonable (not 10x).
+
+(The pre-existing `debug.PrintStack()` noise from `samfile.go:390` will still appear on stderr; that's tracked in issue #19 separately.)
+
+- [ ] **Step 4: Run verify on the M0 boot disk if present**
+
+```
+[ -f /Users/pmoore/git/sam-aarch64/build/test.mgt ] && /tmp/samfile-phase4 verify -i /Users/pmoore/git/sam-aarch64/build/test.mgt 2>/dev/null | head -30 || echo "no M0 disk; skipping"
+```
+Expected: `detected dialect: samdos2`. The M0 boot disk should be clean (no findings) per Phase 3's smoke, and the Phase 4 rules also expect zero findings on a samfile-built CODE-only disk:
+
+- The body-header mirror rules pass because samfile's `CreateHeader` (samfile.go:921-937) emits bytes that match the dir entry by construction.
+- `BODY-BYTES-5-6-CANONICAL-FF` does NOT fire on no-auto-exec CODE files because samfile writes `{0xFF, 0xFF}` (CreateHeader defaults), not `{0xFF, 0x00}`.
+- `BODY-PAGEOFFSET-8000H-FORM` does NOT fire because `AddCodeFile` sets `StartAddressPageOffset = (loadAddr & 0x3FFF) | 0x8000`, which always has bit 15 set.
+- `BODY-PAGE-LE-31` does NOT fire because all M0 CODE files load at 0x8000 or 491529 — both well within the page index range.
+- `CODE-*` rules pass because `AddCodeFile` enforces load address, length, and exec address invariants at SAVE time.
+
+**If ANY rule fires on M0, stop and investigate before pushing.** A finding on a known-clean boot disk is a real bug — most likely either a rule with the wrong threshold or a samfile writer quirk we didn't account for.
+
+- [ ] **Step 5: Push**
+
+```bash
+cd /Users/pmoore/git/samfile-verify-phase-4 && g push -u origin feat/verify-phase-4-body-header-ftcode
+```
+
+- [ ] **Step 6: Open the draft PR**
+
+```bash
+cd /Users/pmoore/git/samfile-verify-phase-4 && gh pr create --draft --base master \
+  --title "verify: Phase 4 — body-header & FT_CODE rules (15 rules)" \
+  --body "$(cat <<'EOF'
+Phase 4 of `samfile verify` (spec: `docs/specs/2026-05-11-verify-feature-design.md`, plan: `docs/plans/2026-05-12-verify-phase-4-body-header-ftcode.md`). Implements 15 of the catalog's §5 (body-header consistency) and §6 (FT_CODE-specific) rules. After this lands the registry holds 35 rules total (Phase-1 smoke + 19 Phase-3 + 15 Phase-4); file-type rules for FT_SAM_BASIC / FT_NUM_ARRAY / FT_STR_ARRAY / FT_SCREEN / FT_ZX_SNAPSHOT follow in Phase 5.
+
+## Rules added
+
+**§5 body-header byte-mirror rules** (8): `BODY-TYPE-MATCHES-DIR`, `BODY-LENGTHMOD16K-MATCHES-DIR`, `BODY-PAGEOFFSET-MATCHES-DIR`, `BODY-EXEC-DIV16K-MATCHES-DIR`, `BODY-EXEC-MOD16K-LO-MATCHES-DIR`, `BODY-PAGES-MATCHES-DIR`, `BODY-STARTPAGE-MATCHES-DIR`, `BODY-MIRROR-AT-DIR-D3-DB`
+
+**§5 body-header format rules** (3): `BODY-PAGEOFFSET-8000H-FORM`, `BODY-PAGE-LE-31`, `BODY-BYTES-5-6-CANONICAL-FF`
+
+**§6 FT_CODE rules** (4): `CODE-LOAD-ABOVE-ROM`, `CODE-LOAD-FITS-IN-MEMORY`, `CODE-EXEC-WITHIN-LOADED-RANGE`, `CODE-FILETYPEINFO-EMPTY`
+
+Severity distribution: 2 fatal, 3 structural, 7 inconsistency, 3 cosmetic.
+
+## Deliberately deferred
+
+- `BODY-HEADER-AT-FIRST-SECTOR` — parser invariant; the first 9 bytes of any used file's FirstSector are the body header by definition. No falsifiable check.
+- `CODE-EXEC-FF-DISABLES` — documents `LOAD CODE` behaviour ("dir[0xF2]==0xFF means no auto-exec"), not a runtime invariant. Nothing to assert.
+
+## Architecture
+
+- One file per catalog section: `rules_body_header.go` (§5) and `rules_ft_code.go` (§6).
+- Two private helpers in `rules_body_header.go`:
+  - `bodyHeaderRaw(*DiskImage, *FileEntry) ([9]byte, error)` reads the 9-byte body header at a file's first sector. Used by every §5 rule; isolates the SectorData call so rules don't reach into raw byte I/O.
+  - `bodyDirMirrorFinding(...)` standardises the "body byte X mismatches dir field Y" Finding shape across the 5 single-byte mirror rules.
+- §6 rules filter on `fe.Type == FT_CODE` at the top of each Check function — no new helper for four rules.
+
+## CLI smoke
+
+- **M0 boot disk** (`../sam-aarch64/build/test.mgt`): clean — `detected dialect: samdos2`, no findings. Confirms Phase 4 doesn't false-positive on a known-good samfile-built disk.
+- **`testdata/ETrackerv1.2.mgt`**: substantially more findings than Phase 3's 350 (Phase 4's rules fire heavily on this disk). Distribution by severity inspected; no panics, every RuleID is registered.
+
+## Note on `TestCodeLoadAboveROMNegative`
+
+`samfile.FileHeader.Start()`'s `+1` shift makes Start()<0x4000 unreachable via any FileEntry field combination. The negative test is `t.Skip`'d with a documentation comment. The rule itself matches the catalog and runs cleanly; Phase 7's raw-byte fixtures may exercise it.
+
+## Test plan
+
+- [x] `go test ./...` — all green (28 new positive/negative tests + 2 from the skip case; registry gate now 35)
+- [x] `go vet ./...` — clean
+- [x] CLI smoke against `testdata/ETrackerv1.2.mgt` produces a structurally well-formed report
+- [x] CLI smoke against the M0 boot disk reports `samdos2` and only documented-expected findings
+- [ ] GitHub Actions CI green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 7: Monitor CI**
+
+```bash
+cd /Users/pmoore/git/samfile-verify-phase-4 && gh pr checks --watch
+```
+
+Per Pete's standing rule, do NOT mark the PR ready-for-review until Pete approves. Fix CI failures autonomously and iterate.
+
+- [ ] **Step 8: Hand off**
+
+Reply with the PR URL, CI status, the M0 disk's finding list (if any), and the ETracker corpus' finding distribution by severity.
+
+---
+
+## Self-review notes
+
+**Spec coverage walk-through:**
+
+| Spec requirement (§"Implementation order" Phase 4) | Where in plan |
+|---|---|
+| Body-header rules (§5) — 11 implementable | Tasks 2 + 3 |
+| FT_CODE rules (§6) — 4 implementable | Task 4 |
+| "Includes BODY-EXEC-DIV16K-MATCHES-DIR and BODY-EXEC-MOD16K-LO-MATCHES-DIR as simplest demonstrations" | Task 2, single-byte mirror block (both are 1-byte mirrors) |
+| All rules dialect-agnostic | Every Register block omits the Dialects field |
+| Two catalog entries deferred with rationale | Plan body table |
+
+15 in-scope rules, 2 explicitly-deferred catalog entries, one helper (`bodyHeaderRaw`), one DRY helper (`bodyDirMirrorFinding`), one test-fixture utility (`mutateFirstSectorByte`). Spec covered.
+
+**Placeholder scan:** every Check function is spelled out or follows the explicit table for the 5 single-byte mirrors. Every test has a concrete mutation. Every commit message is given verbatim. No TBDs.
+
+**Type / signature consistency:**
+
+- `bodyHeaderRaw(di *DiskImage, fe *FileEntry) ([9]byte, error)` — Tasks 1, 2, 3.
+- `bodyDirMirrorFinding(ruleID string, sev Severity, citation, fieldName string, slot int, name string, expected, actual uint8) []Finding` — Tasks 1 + 2 (5 callers).
+- `mutateFirstSectorByte(t *testing.T, di *DiskImage, byteOffset int, newValue byte)` — Tasks 2 + 3.
+- `forEachUsedSlot` (Phase 3) — used in every §5 and §6 rule.
+- `cleanSingleFileDisk` (Phase 3) — used in every test.
+
+All consistent.
+
+**Rule severity sanity check (15 rules total):**
+
+| Severity | Count | Rules |
+|---|---|---|
+| Fatal | 2 | CODE-LOAD-ABOVE-ROM, CODE-LOAD-FITS-IN-MEMORY |
+| Structural | 3 | BODY-EXEC-DIV16K-MATCHES-DIR, BODY-PAGE-LE-31, CODE-EXEC-WITHIN-LOADED-RANGE |
+| Inconsistency | 7 | BODY-TYPE-MATCHES-DIR, BODY-LENGTHMOD16K-MATCHES-DIR, BODY-PAGEOFFSET-MATCHES-DIR, BODY-EXEC-MOD16K-LO-MATCHES-DIR, BODY-PAGES-MATCHES-DIR, BODY-STARTPAGE-MATCHES-DIR, BODY-MIRROR-AT-DIR-D3-DB |
+| Cosmetic | 3 | BODY-PAGEOFFSET-8000H-FORM, BODY-BYTES-5-6-CANONICAL-FF, CODE-FILETYPEINFO-EMPTY |
+
+Total: 2 + 3 + 7 + 3 = 15 ✓. Registry final count after Task 4 = 35 (Phase-1 smoke + 19 Phase-3 + 15 Phase-4).

--- a/rules_body_header.go
+++ b/rules_body_header.go
@@ -82,11 +82,17 @@ func checkBodyTypeMatchesDir(ctx *CheckContext) []Finding {
 }
 
 // ----- BODY-EXEC-DIV16K-MATCHES-DIR -----
+// Scoped to FT_CODE only. Dir bytes 0xF2-0xF4 are repurposed for
+// non-CODE file types: FT_SAM_BASIC stores the auto-RUN line number
+// there (0x00 marker + 16-bit line), while samfile's CreateHeader
+// (samfile.go:921-927) emits 0xFF for body[5] on every non-CODE
+// file regardless of dir contents. The "mirror" only holds for
+// CODE files where both sides encode the same exec-address.
 func init() {
 	Register(Rule{
 		ID:          "BODY-EXEC-DIV16K-MATCHES-DIR",
 		Severity:    SeverityStructural,
-		Description: "body header ExecutionAddressDiv16K (byte 5) equals dir-entry ExecutionAddressDiv16K",
+		Description: "FT_CODE body-header ExecutionAddressDiv16K (byte 5) equals dir-entry ExecutionAddressDiv16K",
 		Citation:    "rom-disasm:22471-22484",
 		Check:       checkBodyExecDiv16KMatchesDir,
 	})
@@ -95,6 +101,9 @@ func init() {
 func checkBodyExecDiv16KMatchesDir(ctx *CheckContext) []Finding {
 	var findings []Finding
 	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		if fe.Type != FT_CODE {
+			return
+		}
 		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
 		if err != nil {
 			return
@@ -109,11 +118,15 @@ func checkBodyExecDiv16KMatchesDir(ctx *CheckContext) []Finding {
 }
 
 // ----- BODY-EXEC-MOD16K-LO-MATCHES-DIR -----
+// Scoped to FT_CODE only — same reasoning as BODY-EXEC-DIV16K-MATCHES-DIR.
+// For non-CODE files, dir's ExecutionAddressMod16K holds the auto-RUN
+// line (BASIC) or other type-specific data while body[6] is always
+// 0xFF (CreateHeader's non-FT_CODE default).
 func init() {
 	Register(Rule{
 		ID:          "BODY-EXEC-MOD16K-LO-MATCHES-DIR",
 		Severity:    SeverityInconsistency,
-		Description: "body header ExecutionAddressMod16KLo (byte 6) equals low byte of dir-entry ExecutionAddressMod16K",
+		Description: "FT_CODE body-header ExecutionAddressMod16KLo (byte 6) equals low byte of dir-entry ExecutionAddressMod16K",
 		Citation:    "rom-disasm:22472",
 		Check:       checkBodyExecMod16KLoMatchesDir,
 	})
@@ -122,6 +135,9 @@ func init() {
 func checkBodyExecMod16KLoMatchesDir(ctx *CheckContext) []Finding {
 	var findings []Finding
 	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		if fe.Type != FT_CODE {
+			return
+		}
 		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
 		if err != nil {
 			return

--- a/rules_body_header.go
+++ b/rules_body_header.go
@@ -298,3 +298,114 @@ func checkBodyMirrorAtDirD3DB(ctx *CheckContext) []Finding {
 	})
 	return findings
 }
+
+// ----- BODY-PAGEOFFSET-8000H-FORM -----
+// Real ROM SAVE writes PageOffset with bit 15 set ("8000H form" / REL
+// PAGE FORM convention, Tech Manual L3037-3052). Both samfile.Start()
+// and the ROM PDPSR2 decoder mask & 0x3FFF before use, so a bit-15-
+// clear value still parses — but it deviates from convention and is
+// a useful corpus-validation signal.
+func init() {
+	Register(Rule{
+		ID:          "BODY-PAGEOFFSET-8000H-FORM",
+		Severity:    SeverityCosmetic,
+		Description: "body-header PageOffset has bit 15 set (8000H-form convention)",
+		Citation:    "sam-coupe_tech-man_v3-0.txt:3037-3052",
+		Check:       checkBodyPageOffset8000HForm,
+	})
+}
+
+func checkBodyPageOffset8000HForm(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		pageOffset := uint16(hdr[3]) | uint16(hdr[4])<<8
+		// A zero offset is a legitimate "page-aligned" load; only warn
+		// when there are bits in the low 14 but bit 15 is clear.
+		if pageOffset != 0 && pageOffset&0x8000 == 0 {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-PAGEOFFSET-8000H-FORM",
+				Severity: SeverityCosmetic,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("body PageOffset = 0x%04x is missing bit 15 (8000H-form convention)", pageOffset),
+				Citation: "sam-coupe_tech-man_v3-0.txt:3037-3052",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- BODY-PAGE-LE-31 -----
+// body[8] & 0x1F is the page index BEFORE samfile's +1 shift in
+// FileHeader.Start(). Index 31 (raw) gives a +1 of 32, which lands
+// the load address at 0x80000 (off-disk pseudo-page used as a
+// marker, e.g. by SAMBASIC). Real on-disk load addresses use 0..30.
+func init() {
+	Register(Rule{
+		ID:          "BODY-PAGE-LE-31",
+		Severity:    SeverityStructural,
+		Description: "body-header StartPage's low 5 bits encode an on-disk page index (0..30)",
+		Citation:    "samfile.go:248-249",
+		Check:       checkBodyPageLE31,
+	})
+}
+
+func checkBodyPageLE31(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		page := hdr[8] & 0x1F
+		if page > 30 {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-PAGE-LE-31",
+				Severity: SeverityStructural,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("body StartPage low-5 bits = %d (>30); +1 shift lands above on-disk pages", page),
+				Citation: "samfile.go:248-249",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- BODY-BYTES-5-6-CANONICAL-FF -----
+// When ExecutionAddressDiv16K (body[5]) is 0xFF (the "no auto-exec"
+// marker), real ROM SAVE writes 0xFF to body[6] as well — both bytes
+// 0xFF are the canonical "no auto-exec" pair. samfile's writer emits
+// 0x00 for body[6] in that case (samfile.go:1011-1023). Both parse
+// identically, but the convention is FF FF.
+func init() {
+	Register(Rule{
+		ID:          "BODY-BYTES-5-6-CANONICAL-FF",
+		Severity:    SeverityCosmetic,
+		Description: "when body[5]==0xFF (no auto-exec), real SAVE writes body[6]==0xFF too",
+		Citation:    "rom-disasm:22076-22080",
+		Check:       checkBodyBytes56CanonicalFF,
+	})
+}
+
+func checkBodyBytes56CanonicalFF(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		if hdr[5] == 0xFF && hdr[6] != 0xFF {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-BYTES-5-6-CANONICAL-FF",
+				Severity: SeverityCosmetic,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("body[5]=0xFF (no auto-exec) but body[6]=0x%02x; canonical SAVE writes 0xFF here too", hdr[6]),
+				Citation: "rom-disasm:22076-22080",
+			})
+		}
+	})
+	return findings
+}

--- a/rules_body_header.go
+++ b/rules_body_header.go
@@ -53,3 +53,248 @@ func bodyDirMirrorFinding(
 		Citation: citation,
 	}}
 }
+
+// ----- BODY-TYPE-MATCHES-DIR -----
+func init() {
+	Register(Rule{
+		ID:          "BODY-TYPE-MATCHES-DIR",
+		Severity:    SeverityInconsistency,
+		Description: "body header Type byte equals directory-entry Type (attribute bits masked)",
+		Citation:    "samdos/src/c.s:1395-1408",
+		Check:       checkBodyTypeMatchesDir,
+	})
+}
+
+func checkBodyTypeMatchesDir(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return // §1 rules already report the underlying first-sector problem
+		}
+		findings = append(findings, bodyDirMirrorFinding(
+			"BODY-TYPE-MATCHES-DIR", SeverityInconsistency, "samdos/src/c.s:1395-1408", "type",
+			slot, fe.Name.String(),
+			uint8(fe.Type)&0x1F, hdr[0],
+		)...)
+	})
+	return findings
+}
+
+// ----- BODY-EXEC-DIV16K-MATCHES-DIR -----
+func init() {
+	Register(Rule{
+		ID:          "BODY-EXEC-DIV16K-MATCHES-DIR",
+		Severity:    SeverityStructural,
+		Description: "body header ExecutionAddressDiv16K (byte 5) equals dir-entry ExecutionAddressDiv16K",
+		Citation:    "rom-disasm:22471-22484",
+		Check:       checkBodyExecDiv16KMatchesDir,
+	})
+}
+
+func checkBodyExecDiv16KMatchesDir(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		findings = append(findings, bodyDirMirrorFinding(
+			"BODY-EXEC-DIV16K-MATCHES-DIR", SeverityStructural, "rom-disasm:22471-22484", "ExecutionAddressDiv16K",
+			slot, fe.Name.String(),
+			fe.ExecutionAddressDiv16K, hdr[5],
+		)...)
+	})
+	return findings
+}
+
+// ----- BODY-EXEC-MOD16K-LO-MATCHES-DIR -----
+func init() {
+	Register(Rule{
+		ID:          "BODY-EXEC-MOD16K-LO-MATCHES-DIR",
+		Severity:    SeverityInconsistency,
+		Description: "body header ExecutionAddressMod16KLo (byte 6) equals low byte of dir-entry ExecutionAddressMod16K",
+		Citation:    "rom-disasm:22472",
+		Check:       checkBodyExecMod16KLoMatchesDir,
+	})
+}
+
+func checkBodyExecMod16KLoMatchesDir(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		findings = append(findings, bodyDirMirrorFinding(
+			"BODY-EXEC-MOD16K-LO-MATCHES-DIR", SeverityInconsistency, "rom-disasm:22472", "ExecutionAddressMod16KLo",
+			slot, fe.Name.String(),
+			uint8(fe.ExecutionAddressMod16K&0xFF), hdr[6],
+		)...)
+	})
+	return findings
+}
+
+// ----- BODY-PAGES-MATCHES-DIR -----
+func init() {
+	Register(Rule{
+		ID:          "BODY-PAGES-MATCHES-DIR",
+		Severity:    SeverityInconsistency,
+		Description: "body header Pages (byte 7) equals dir-entry Pages",
+		Citation:    "samdos/src/c.s:1376-1379",
+		Check:       checkBodyPagesMatchesDir,
+	})
+}
+
+func checkBodyPagesMatchesDir(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		findings = append(findings, bodyDirMirrorFinding(
+			"BODY-PAGES-MATCHES-DIR", SeverityInconsistency, "samdos/src/c.s:1376-1379", "Pages",
+			slot, fe.Name.String(),
+			fe.Pages, hdr[7],
+		)...)
+	})
+	return findings
+}
+
+// ----- BODY-STARTPAGE-MATCHES-DIR -----
+func init() {
+	Register(Rule{
+		ID:          "BODY-STARTPAGE-MATCHES-DIR",
+		Severity:    SeverityInconsistency,
+		Description: "body header StartPage (byte 8) equals dir-entry StartAddressPage",
+		Citation:    "samdos/src/c.s:1376-1379",
+		Check:       checkBodyStartPageMatchesDir,
+	})
+}
+
+func checkBodyStartPageMatchesDir(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		findings = append(findings, bodyDirMirrorFinding(
+			"BODY-STARTPAGE-MATCHES-DIR", SeverityInconsistency, "samdos/src/c.s:1376-1379", "StartAddressPage",
+			slot, fe.Name.String(),
+			fe.StartAddressPage, hdr[8],
+		)...)
+	})
+	return findings
+}
+
+// ----- BODY-LENGTHMOD16K-MATCHES-DIR -----
+func init() {
+	Register(Rule{
+		ID:          "BODY-LENGTHMOD16K-MATCHES-DIR",
+		Severity:    SeverityInconsistency,
+		Description: "body header LengthMod16K (bytes 1-2 LE) equals dir-entry LengthMod16K",
+		Citation:    "samdos/src/c.s:1376-1379",
+		Check:       checkBodyLengthMod16KMatchesDir,
+	})
+}
+
+func checkBodyLengthMod16KMatchesDir(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		actual := uint16(hdr[1]) | uint16(hdr[2])<<8
+		if actual != fe.LengthMod16K {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-LENGTHMOD16K-MATCHES-DIR",
+				Severity: SeverityInconsistency,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("body LengthMod16K = 0x%04x but dir says 0x%04x", actual, fe.LengthMod16K),
+				Citation: "samdos/src/c.s:1376-1379",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- BODY-PAGEOFFSET-MATCHES-DIR -----
+func init() {
+	Register(Rule{
+		ID:          "BODY-PAGEOFFSET-MATCHES-DIR",
+		Severity:    SeverityInconsistency,
+		Description: "body header PageOffset (bytes 3-4 LE) equals dir-entry StartAddressPageOffset",
+		Citation:    "samdos/src/c.s:1376-1379",
+		Check:       checkBodyPageOffsetMatchesDir,
+	})
+}
+
+func checkBodyPageOffsetMatchesDir(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		actual := uint16(hdr[3]) | uint16(hdr[4])<<8
+		if actual != fe.StartAddressPageOffset {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-PAGEOFFSET-MATCHES-DIR",
+				Severity: SeverityInconsistency,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("body PageOffset = 0x%04x but dir says 0x%04x", actual, fe.StartAddressPageOffset),
+				Citation: "samdos/src/c.s:1376-1379",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- BODY-MIRROR-AT-DIR-D3-DB -----
+func init() {
+	Register(Rule{
+		ID:          "BODY-MIRROR-AT-DIR-D3-DB",
+		Severity:    SeverityInconsistency,
+		Description: "dir bytes 0xD3..0xDB mirror body header bytes 0..8 (and dir byte 0xD2 is 0)",
+		Citation:    "samdos/src/f.s:462-471",
+		Check:       checkBodyMirrorAtDirD3DB,
+	})
+}
+
+func checkBodyMirrorAtDirD3DB(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
+		if err != nil {
+			return
+		}
+		// dir byte 0xD2 == 0 (MGTFutureAndPast[0])
+		if fe.MGTFutureAndPast[0] != 0 {
+			findings = append(findings, Finding{
+				RuleID:   "BODY-MIRROR-AT-DIR-D3-DB",
+				Severity: SeverityInconsistency,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("dir byte 0xD2 (MGTFutureAndPast[0]) = 0x%02x but should be 0", fe.MGTFutureAndPast[0]),
+				Citation: "samdos/src/f.s:462-471",
+			})
+		}
+		// dir bytes 0xD3..0xDB (MGTFutureAndPast[1..9]) mirror body bytes 0..8
+		for i := 0; i < 9; i++ {
+			if fe.MGTFutureAndPast[1+i] != hdr[i] {
+				findings = append(findings, Finding{
+					RuleID:   "BODY-MIRROR-AT-DIR-D3-DB",
+					Severity: SeverityInconsistency,
+					Location: SlotLocation(slot, fe.Name.String()),
+					Message: fmt.Sprintf("dir byte 0x%02x (MGTFutureAndPast[%d]) = 0x%02x but body byte %d = 0x%02x",
+						0xD3+i, 1+i, fe.MGTFutureAndPast[1+i], i, hdr[i]),
+					Citation: "samdos/src/f.s:462-471",
+				})
+				return // one finding per slot is enough; the disagreement is the signal
+			}
+		}
+	})
+	return findings
+}

--- a/rules_body_header.go
+++ b/rules_body_header.go
@@ -377,9 +377,11 @@ func checkBodyPageLE31(ctx *CheckContext) []Finding {
 // ----- BODY-BYTES-5-6-CANONICAL-FF -----
 // When ExecutionAddressDiv16K (body[5]) is 0xFF (the "no auto-exec"
 // marker), real ROM SAVE writes 0xFF to body[6] as well — both bytes
-// 0xFF are the canonical "no auto-exec" pair. samfile's writer emits
-// 0x00 for body[6] in that case (samfile.go:1011-1023). Both parse
-// identically, but the convention is FF FF.
+// 0xFF are the canonical "no auto-exec" pair. samfile's writer also
+// emits 0xFF for body[6] in that case via CreateHeader (samfile.go:921-937),
+// so this rule fires only on hand-edited or legacy files where body[5]
+// is 0xFF but body[6] is something else. Both forms parse identically;
+// the rule documents the {FF, FF} convention.
 func init() {
 	Register(Rule{
 		ID:          "BODY-BYTES-5-6-CANONICAL-FF",

--- a/rules_body_header.go
+++ b/rules_body_header.go
@@ -1,0 +1,55 @@
+package samfile
+
+import "fmt"
+
+// §5 Body-header rules (catalog docs/disk-validity-rules.md §5).
+// Rules in this file compare the 9-byte body header at each used
+// file's first sector against the parsed directory-entry fields it
+// is supposed to mirror, plus a handful of byte-level format
+// invariants that don't have a dir-entry counterpart. They apply to
+// all dialects.
+//
+// bodyHeaderRaw (private) reads the 9-byte header once per rule
+// invocation; bodyDirMirrorFinding (private) standardises the
+// "body field X mismatches dir field Y" Finding shape.
+
+// bodyHeaderRaw reads the 9 leading bytes of fe's body — the on-disk
+// FileHeader bytes (Type, LengthMod16K-lo, LengthMod16K-hi, PageOffset-lo,
+// PageOffset-hi, ExecutionAddressDiv16K, ExecutionAddressMod16KLo, Pages,
+// StartPage). Returns an error if fe.FirstSector is unreadable; rules
+// should treat that as "no finding" because §1 / §2 rules already report
+// the underlying first-sector problem.
+//
+// This is a thin convenience over SectorData(fe.FirstSector); it does
+// not allocate beyond the returned array.
+func bodyHeaderRaw(di *DiskImage, fe *FileEntry) ([9]byte, error) {
+	var hdr [9]byte
+	sd, err := di.SectorData(fe.FirstSector)
+	if err != nil {
+		return hdr, err
+	}
+	copy(hdr[:], sd[:9])
+	return hdr, nil
+}
+
+// bodyDirMirrorFinding compares one expected (dir-derived) value to one
+// actual (body-derived) value and returns either nil or a single Finding
+// pinpointing the mismatch. The same shape is used by every §5 byte-mirror
+// rule — RuleID, Severity, Citation, and a human-readable fieldName feed
+// into a uniform message format.
+func bodyDirMirrorFinding(
+	ruleID string, sev Severity, citation, fieldName string,
+	slot int, name string,
+	expected, actual uint8,
+) []Finding {
+	if expected == actual {
+		return nil
+	}
+	return []Finding{{
+		RuleID:   ruleID,
+		Severity: sev,
+		Location: SlotLocation(slot, name),
+		Message:  fmt.Sprintf("body %s = 0x%02x but dir says 0x%02x", fieldName, actual, expected),
+		Citation: citation,
+	}}
+}

--- a/rules_body_header_test.go
+++ b/rules_body_header_test.go
@@ -1,0 +1,211 @@
+package samfile
+
+import "testing"
+
+// mutateFirstSectorByte patches one byte of slot 0's first sector
+// payload (e.g. body header bytes). It's a small utility for the
+// body-header tests' negative cases; raw byte-level mutation is
+// the only way to disturb the body header without re-running the
+// whole AddCodeFile path (which would re-mirror to the dir entry).
+func mutateFirstSectorByte(t *testing.T, di *DiskImage, byteOffset int, newValue byte) {
+	t.Helper()
+	fe := di.DiskJournal()[0]
+	sd, err := di.SectorData(fe.FirstSector)
+	if err != nil {
+		t.Fatalf("SectorData: %v", err)
+	}
+	sd[byteOffset] = newValue
+	di.WriteSector(fe.FirstSector, sd)
+}
+
+// ----- BODY-TYPE-MATCHES-DIR -----
+
+func TestBodyTypeMatchesDirPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyTypeMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyTypeMatchesDirNegative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	// Patch body byte 0 (Type) to a value the dir doesn't reflect.
+	mutateFirstSectorByte(t, di, 0, 0x05) // body says ZX_SNAPSHOT, dir says CODE
+	findings := checkBodyTypeMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-TYPE-MATCHES-DIR" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-TYPE-MATCHES-DIR", len(findings), findings)
+	}
+}
+
+// ----- BODY-EXEC-DIV16K-MATCHES-DIR -----
+
+func TestBodyExecDiv16KMatchesDirPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyExecDiv16KMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyExecDiv16KMatchesDirNegative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	// Dir's ExecutionAddressDiv16K is 0xFF for AddCodeFile(..., 0) (no auto-exec); 0x7E differs.
+	mutateFirstSectorByte(t, di, 5, 0x7E)
+	findings := checkBodyExecDiv16KMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-EXEC-DIV16K-MATCHES-DIR" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-EXEC-DIV16K-MATCHES-DIR", len(findings), findings)
+	}
+}
+
+// ----- BODY-EXEC-MOD16K-LO-MATCHES-DIR -----
+
+func TestBodyExecMod16KLoMatchesDirPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyExecMod16KLoMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyExecMod16KLoMatchesDirNegative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	// Dir's ExecutionAddressMod16K low byte is 0xFF for no-exec; 0xAA differs.
+	mutateFirstSectorByte(t, di, 6, 0xAA)
+	findings := checkBodyExecMod16KLoMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-EXEC-MOD16K-LO-MATCHES-DIR" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-EXEC-MOD16K-LO-MATCHES-DIR", len(findings), findings)
+	}
+}
+
+// ----- BODY-PAGES-MATCHES-DIR -----
+
+func TestBodyPagesMatchesDirPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyPagesMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyPagesMatchesDirNegative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	// Dir's Pages for a 100-byte CODE file is 0; 0x99 differs.
+	mutateFirstSectorByte(t, di, 7, 0x99)
+	findings := checkBodyPagesMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-PAGES-MATCHES-DIR" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-PAGES-MATCHES-DIR", len(findings), findings)
+	}
+}
+
+// ----- BODY-STARTPAGE-MATCHES-DIR -----
+
+func TestBodyStartPageMatchesDirPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyStartPageMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyStartPageMatchesDirNegative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	// Dir's StartAddressPage for load 0x8000 is 1; 0x99 differs.
+	mutateFirstSectorByte(t, di, 8, 0x99)
+	findings := checkBodyStartPageMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-STARTPAGE-MATCHES-DIR" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-STARTPAGE-MATCHES-DIR", len(findings), findings)
+	}
+}
+
+// ----- BODY-LENGTHMOD16K-MATCHES-DIR -----
+
+func TestBodyLengthMod16KMatchesDirPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyLengthMod16KMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyLengthMod16KMatchesDirNegative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	// Patching byte 1 alone disagrees with the dir's parsed 16-bit LengthMod16K.
+	mutateFirstSectorByte(t, di, 1, 0xAA)
+	findings := checkBodyLengthMod16KMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-LENGTHMOD16K-MATCHES-DIR" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-LENGTHMOD16K-MATCHES-DIR", len(findings), findings)
+	}
+}
+
+// ----- BODY-PAGEOFFSET-MATCHES-DIR -----
+
+func TestBodyPageOffsetMatchesDirPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyPageOffsetMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyPageOffsetMatchesDirNegative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	// Same shape as LengthMod16K, byte 3.
+	mutateFirstSectorByte(t, di, 3, 0xAA)
+	findings := checkBodyPageOffsetMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-PAGEOFFSET-MATCHES-DIR" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-PAGEOFFSET-MATCHES-DIR", len(findings), findings)
+	}
+}
+
+// ----- BODY-MIRROR-AT-DIR-D3-DB -----
+
+func TestBodyMirrorAtDirD3DBPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyMirrorAtDirD3DB(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyMirrorAtDirD3DBNegative(t *testing.T) {
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	dj[0].MGTFutureAndPast[0] = 0xFF
+	di.WriteFileEntry(dj, 0)
+	findings := checkBodyMirrorAtDirD3DB(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-MIRROR-AT-DIR-D3-DB" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-MIRROR-AT-DIR-D3-DB", len(findings), findings)
+	}
+}

--- a/rules_body_header_test.go
+++ b/rules_body_header_test.go
@@ -90,6 +90,39 @@ func TestBodyExecMod16KLoMatchesDirNegative(t *testing.T) {
 	}
 }
 
+func TestBodyExecDiv16KMatchesDirSkipsNonCode(t *testing.T) {
+	// Morph the CODE slot into a BASIC-like one: Type=FT_SAM_BASIC and
+	// dir's exec bytes set to BASIC's auto-RUN pattern. Body byte 5
+	// remains 0xFF (samfile's non-FT_CODE CreateHeader default) which
+	// would trip the rule under all-types semantics. With FT_CODE
+	// scoping the rule must skip this slot.
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	dj[0].Type = FT_SAM_BASIC
+	dj[0].ExecutionAddressDiv16K = 0x00 // BASIC auto-RUN marker
+	dj[0].ExecutionAddressMod16K = 10   // line number
+	di.WriteFileEntry(dj, 0)
+	findings := checkBodyExecDiv16KMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("FT_SAM_BASIC slot: %d findings; want 0 (rule must skip non-CODE)", len(findings))
+	}
+}
+
+func TestBodyExecMod16KLoMatchesDirSkipsNonCode(t *testing.T) {
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	dj[0].Type = FT_SAM_BASIC
+	dj[0].ExecutionAddressDiv16K = 0x00
+	dj[0].ExecutionAddressMod16K = 10
+	di.WriteFileEntry(dj, 0)
+	findings := checkBodyExecMod16KLoMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("FT_SAM_BASIC slot: %d findings; want 0 (rule must skip non-CODE)", len(findings))
+	}
+}
+
 // ----- BODY-PAGES-MATCHES-DIR -----
 
 func TestBodyPagesMatchesDirPositive(t *testing.T) {

--- a/rules_body_header_test.go
+++ b/rules_body_header_test.go
@@ -209,3 +209,68 @@ func TestBodyMirrorAtDirD3DBNegative(t *testing.T) {
 		t.Fatalf("got %d findings, first=%+v; want 1 BODY-MIRROR-AT-DIR-D3-DB", len(findings), findings)
 	}
 }
+
+// ----- BODY-PAGEOFFSET-8000H-FORM -----
+
+func TestBodyPageOffset8000HFormPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyPageOffset8000HForm(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyPageOffset8000HFormNegative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	// Patch body bytes 3-4 to a non-zero offset with bit 15 clear (0x12 0x34 = 0x3412).
+	mutateFirstSectorByte(t, di, 3, 0x12)
+	mutateFirstSectorByte(t, di, 4, 0x34)
+	findings := checkBodyPageOffset8000HForm(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-PAGEOFFSET-8000H-FORM" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-PAGEOFFSET-8000H-FORM", len(findings), findings)
+	}
+}
+
+// ----- BODY-PAGE-LE-31 -----
+
+func TestBodyPageLE31Positive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyPageLE31(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyPageLE31Negative(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	mutateFirstSectorByte(t, di, 8, 0x1F) // low-5 = 31, exceeds 30
+	findings := checkBodyPageLE31(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-PAGE-LE-31" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-PAGE-LE-31", len(findings), findings)
+	}
+}
+
+// ----- BODY-BYTES-5-6-CANONICAL-FF -----
+
+func TestBodyBytes56CanonicalFFPositive(t *testing.T) {
+	// samfile's AddCodeFile(...,exec=0) sets fe.ExecutionAddressDiv16K = 0xFF
+	// and fe.ExecutionAddressMod16K = 0xFFFF; CreateHeader (samfile.go:921)
+	// in turn emits body[5]=0xFF, body[6]=0xFF — the canonical pair this
+	// rule expects. A clean disk therefore yields no findings.
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkBodyBytes56CanonicalFF(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("clean no-auto-exec disk (body[5..6]={0xFF, 0xFF}): %d findings; want 0", len(findings))
+	}
+}
+
+func TestBodyBytes56CanonicalFFNegative(t *testing.T) {
+	// Patch body[6] alone to 0x00, leaving body[5]=0xFF. The {0xFF, 0x00}
+	// pair is the non-canonical mix this cosmetic rule warns about.
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	mutateFirstSectorByte(t, di, 6, 0x00)
+	findings := checkBodyBytes56CanonicalFF(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "BODY-BYTES-5-6-CANONICAL-FF" {
+		t.Fatalf("got %d findings, first=%+v; want 1 BODY-BYTES-5-6-CANONICAL-FF", len(findings), findings)
+	}
+}

--- a/rules_body_header_test.go
+++ b/rules_body_header_test.go
@@ -176,7 +176,8 @@ func TestBodyPageOffsetMatchesDirPositive(t *testing.T) {
 
 func TestBodyPageOffsetMatchesDirNegative(t *testing.T) {
 	di, _ := cleanSingleFileDisk(t, "TEST", 100)
-	// Same shape as LengthMod16K, byte 3.
+	// Patching byte 3 (PageOffset lo) disagrees with the dir's 16-bit
+	// StartAddressPageOffset.
 	mutateFirstSectorByte(t, di, 3, 0xAA)
 	findings := checkBodyPageOffsetMatchesDir(&CheckContext{
 		Disk: di, Journal: di.DiskJournal(),

--- a/rules_ft_code.go
+++ b/rules_ft_code.go
@@ -1,0 +1,8 @@
+package samfile
+
+// §6 FT_CODE rules (catalog docs/disk-validity-rules.md §6).
+// Rules in this file check FT_CODE-specific invariants: the file's
+// load address is above ROM, the loaded region fits in SAM's 512 KiB
+// address space, the execution address (if not opted out) lies within
+// the loaded region, and dir-entry FileTypeInfo is unused (cosmetic).
+// Each Check function filters on fe.Type == FT_CODE at the top.

--- a/rules_ft_code.go
+++ b/rules_ft_code.go
@@ -111,11 +111,24 @@ func checkCodeExecWithinLoadedRange(ctx *CheckContext) []Finding {
 }
 
 // ----- CODE-FILETYPEINFO-EMPTY -----
+// FileTypeInfo (dir 0xDD-0xE7) is unused for FT_CODE. Two conventions
+// are observed in the wild:
+//
+//   - 0x00 × 11 — samfile's AddCodeFile leaves the struct zero-init.
+//   - 0xFF × 11 — real ROM SAMDOS-2 SAVE 0xFF-fills 14 bytes from
+//     dir offset 0xDC via HDCLP2 (rom-disasm:22076-22080), which
+//     covers MGTFlags + the entire FileTypeInfo region + the first
+//     two bytes of ReservedA.
+//
+// Both are legitimate "unused" markers. The rule warns only when a
+// byte is in NEITHER convention — i.e. anything other than 0x00 or
+// 0xFF, which would suggest the slot was once a different file type
+// whose FileTypeInfo bytes weren't cleared on overwrite.
 func init() {
 	Register(Rule{
 		ID:          "CODE-FILETYPEINFO-EMPTY",
 		Severity:    SeverityCosmetic,
-		Description: "FT_CODE file's FileTypeInfo (dir 0xDD-0xE7) is all zero (samfile convention)",
+		Description: "FT_CODE file's FileTypeInfo (dir 0xDD-0xE7) is uniformly 0x00 (samfile) or 0xFF (ROM SAMDOS-2) — unused-marker convention",
 		Citation:    "samfile.go:798-827",
 		Check:       checkCodeFileTypeInfoEmpty,
 	})
@@ -128,12 +141,12 @@ func checkCodeFileTypeInfoEmpty(ctx *CheckContext) []Finding {
 			return
 		}
 		for _, b := range fe.FileTypeInfo {
-			if b != 0 {
+			if b != 0x00 && b != 0xFF {
 				findings = append(findings, Finding{
 					RuleID:   "CODE-FILETYPEINFO-EMPTY",
 					Severity: SeverityCosmetic,
 					Location: SlotLocation(slot, fe.Name.String()),
-					Message:  "CODE file has non-zero FileTypeInfo (dir 0xDD-0xE7) — samfile leaves these zero",
+					Message:  fmt.Sprintf("CODE file has 0x%02x in FileTypeInfo (dir 0xDD-0xE7) — neither samfile's 0x00 nor ROM SAVE's 0xFF unused-marker", b),
 					Citation: "samfile.go:798-827",
 				})
 				return // one finding per slot

--- a/rules_ft_code.go
+++ b/rules_ft_code.go
@@ -1,8 +1,144 @@
 package samfile
 
+import "fmt"
+
 // §6 FT_CODE rules (catalog docs/disk-validity-rules.md §6).
 // Rules in this file check FT_CODE-specific invariants: the file's
 // load address is above ROM, the loaded region fits in SAM's 512 KiB
 // address space, the execution address (if not opted out) lies within
 // the loaded region, and dir-entry FileTypeInfo is unused (cosmetic).
 // Each Check function filters on fe.Type == FT_CODE at the top.
+
+// ----- CODE-LOAD-ABOVE-ROM -----
+func init() {
+	Register(Rule{
+		ID:          "CODE-LOAD-ABOVE-ROM",
+		Severity:    SeverityFatal,
+		Description: "FT_CODE file's load address is at least 0x4000 (above ROM)",
+		Citation:    "samfile.go:799-801",
+		Check:       checkCodeLoadAboveROM,
+	})
+}
+
+func checkCodeLoadAboveROM(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		if fe.Type != FT_CODE {
+			return
+		}
+		loadAddr := fe.StartAddress()
+		if loadAddr < 0x4000 {
+			findings = append(findings, Finding{
+				RuleID:   "CODE-LOAD-ABOVE-ROM",
+				Severity: SeverityFatal,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("CODE load address 0x%05x is below 0x4000 (ROM)", loadAddr),
+				Citation: "samfile.go:799-801",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- CODE-LOAD-FITS-IN-MEMORY -----
+func init() {
+	Register(Rule{
+		ID:          "CODE-LOAD-FITS-IN-MEMORY",
+		Severity:    SeverityFatal,
+		Description: "FT_CODE file's load address + body length does not exceed SAM's 512 KiB address space",
+		Citation:    "samfile.go:802-804",
+		Check:       checkCodeLoadFitsInMemory,
+	})
+}
+
+func checkCodeLoadFitsInMemory(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		if fe.Type != FT_CODE {
+			return
+		}
+		loadAddr := fe.StartAddress()
+		length := fe.Length()
+		if uint64(loadAddr)+uint64(length) > 0x80000 {
+			findings = append(findings, Finding{
+				RuleID:   "CODE-LOAD-FITS-IN-MEMORY",
+				Severity: SeverityFatal,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message: fmt.Sprintf("CODE load 0x%05x + length 0x%05x = 0x%05x exceeds SAM's 512 KiB address space",
+					loadAddr, length, uint64(loadAddr)+uint64(length)),
+				Citation: "samfile.go:802-804",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- CODE-EXEC-WITHIN-LOADED-RANGE -----
+func init() {
+	Register(Rule{
+		ID:          "CODE-EXEC-WITHIN-LOADED-RANGE",
+		Severity:    SeverityStructural,
+		Description: "FT_CODE file's execution address (when not 0xFF-disabled) lies within its loaded region",
+		Citation:    "samfile.go:805-810",
+		Check:       checkCodeExecWithinLoadedRange,
+	})
+}
+
+func checkCodeExecWithinLoadedRange(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		if fe.Type != FT_CODE {
+			return
+		}
+		if fe.ExecutionAddressDiv16K == 0xFF {
+			return // 0xFF marker = no auto-exec; nothing to validate
+		}
+		execAddr := fe.ExecutionAddress()
+		loadAddr := fe.StartAddress()
+		length := fe.Length()
+		if execAddr < loadAddr || execAddr >= loadAddr+length {
+			findings = append(findings, Finding{
+				RuleID:   "CODE-EXEC-WITHIN-LOADED-RANGE",
+				Severity: SeverityStructural,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message: fmt.Sprintf("CODE exec address 0x%05x is outside loaded region [0x%05x, 0x%05x)",
+					execAddr, loadAddr, loadAddr+length),
+				Citation: "samfile.go:805-810",
+			})
+		}
+	})
+	return findings
+}
+
+// ----- CODE-FILETYPEINFO-EMPTY -----
+func init() {
+	Register(Rule{
+		ID:          "CODE-FILETYPEINFO-EMPTY",
+		Severity:    SeverityCosmetic,
+		Description: "FT_CODE file's FileTypeInfo (dir 0xDD-0xE7) is all zero (samfile convention)",
+		Citation:    "samfile.go:798-827",
+		Check:       checkCodeFileTypeInfoEmpty,
+	})
+}
+
+func checkCodeFileTypeInfoEmpty(ctx *CheckContext) []Finding {
+	var findings []Finding
+	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
+		if fe.Type != FT_CODE {
+			return
+		}
+		for _, b := range fe.FileTypeInfo {
+			if b != 0 {
+				findings = append(findings, Finding{
+					RuleID:   "CODE-FILETYPEINFO-EMPTY",
+					Severity: SeverityCosmetic,
+					Location: SlotLocation(slot, fe.Name.String()),
+					Message:  "CODE file has non-zero FileTypeInfo (dir 0xDD-0xE7) — samfile leaves these zero",
+					Citation: "samfile.go:798-827",
+				})
+				return // one finding per slot
+			}
+		}
+	})
+	return findings
+}

--- a/rules_ft_code_test.go
+++ b/rules_ft_code_test.go
@@ -1,0 +1,96 @@
+package samfile
+
+import "testing"
+
+func TestCodeLoadAboveROMPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100) // load 0x8000
+	findings := checkCodeLoadAboveROM(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("clean CODE file at 0x8000: %d findings; want 0", len(findings))
+	}
+}
+
+func TestCodeLoadAboveROMNegative(t *testing.T) {
+	// AddCodeFile rejects load < 0x4000 (samfile.go:799-801), so we
+	// can't build a violating file via the public API. Patch the
+	// dir entry directly to point below ROM.
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	dj[0].StartAddressPage = 0
+	dj[0].StartAddressPageOffset = 0
+	// Subtract 1 to land at 0x3FFF (below ROM boundary).
+	// Decoded Start() = ((StartPage & 0x1F)+1)<<14 | (PageOffset & 0x3FFF).
+	// We need < 0x4000, so the (+1)<<14 path with StartPage=0 always
+	// gives 0x4000. We need an off-by-one: set StartPage to a value
+	// that, after +1 shift, produces 0x3FFF or below. The only way is
+	// for the formula's & 0x3FFF mask of PageOffset to interact with
+	// (page+1)<<14 — which it can't, since the mask isolates bits.
+	//
+	// Conclusion: samfile.Start()'s +1 shift makes load < 0x4000
+	// unreachable via legal field values. This rule will never fire
+	// on a samfile-parsed disk. Skip the negative test and document.
+	t.Skip("samfile.Start()'s +1 shift makes Start()<0x4000 unreachable via FileEntry fields; rule is documentation-only and exists for parity with the catalog")
+	_ = di
+}
+
+func TestCodeLoadFitsInMemoryPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkCodeLoadFitsInMemory(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("100-byte file at 0x8000: %d findings; want 0", len(findings))
+	}
+}
+
+func TestCodeLoadFitsInMemoryNegative(t *testing.T) {
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	// Patch Pages to 31 (the off-disk pseudo-page marker via samfile's +1)
+	// so length decodes huge AND the load address is near the top of RAM.
+	dj[0].Pages = 31           // length = 31 * 16384 + (LengthMod16K & 0x3FFF)
+	dj[0].LengthMod16K = 0x3FFF // max bits in low 14 bits
+	di.WriteFileEntry(dj, 0)
+	findings := checkCodeLoadFitsInMemory(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "CODE-LOAD-FITS-IN-MEMORY" {
+		t.Fatalf("got %d findings, first=%+v; want 1 CODE-LOAD-FITS-IN-MEMORY", len(findings), findings)
+	}
+}
+
+func TestCodeExecWithinLoadedRangePositive(t *testing.T) {
+	di := NewDiskImage()
+	if err := di.AddCodeFile("TEST", make([]byte, 100), 0x8000, 0x8010); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+	findings := checkCodeExecWithinLoadedRange(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("exec 0x8010 inside [0x8000, 0x8064): %d findings; want 0", len(findings))
+	}
+}
+
+func TestCodeExecWithinLoadedRangeNegative(t *testing.T) {
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	// Set a real exec address (clear the 0xFF marker), but place it
+	// far outside the loaded region [0x8000, 0x8064).
+	dj[0].ExecutionAddressDiv16K = 0x05      // page 5 = 0x14000
+	dj[0].ExecutionAddressMod16K = 0x8000    // offset 0 (PageOffset form)
+	di.WriteFileEntry(dj, 0)
+	findings := checkCodeExecWithinLoadedRange(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "CODE-EXEC-WITHIN-LOADED-RANGE" {
+		t.Fatalf("got %d findings, first=%+v; want 1 CODE-EXEC-WITHIN-LOADED-RANGE", len(findings), findings)
+	}
+}
+
+func TestCodeFileTypeInfoEmptyPositive(t *testing.T) {
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	findings := checkCodeFileTypeInfoEmpty(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("clean disk: %d findings; want 0", len(findings))
+	}
+}
+
+func TestCodeFileTypeInfoEmptyNegative(t *testing.T) {
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	dj[0].FileTypeInfo[5] = 0xAA
+	di.WriteFileEntry(dj, 0)
+	findings := checkCodeFileTypeInfoEmpty(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 1 || findings[0].RuleID != "CODE-FILETYPEINFO-EMPTY" {
+		t.Fatalf("got %d findings, first=%+v; want 1 CODE-FILETYPEINFO-EMPTY", len(findings), findings)
+	}
+}

--- a/rules_ft_code_test.go
+++ b/rules_ft_code_test.go
@@ -87,10 +87,26 @@ func TestCodeFileTypeInfoEmptyPositive(t *testing.T) {
 
 func TestCodeFileTypeInfoEmptyNegative(t *testing.T) {
 	di, dj := cleanSingleFileDisk(t, "TEST", 100)
-	dj[0].FileTypeInfo[5] = 0xAA
+	dj[0].FileTypeInfo[5] = 0xAA // neither 0x00 (samfile) nor 0xFF (ROM SAVE)
 	di.WriteFileEntry(dj, 0)
 	findings := checkCodeFileTypeInfoEmpty(&CheckContext{Disk: di, Journal: di.DiskJournal()})
 	if len(findings) != 1 || findings[0].RuleID != "CODE-FILETYPEINFO-EMPTY" {
 		t.Fatalf("got %d findings, first=%+v; want 1 CODE-FILETYPEINFO-EMPTY", len(findings), findings)
+	}
+}
+
+func TestCodeFileTypeInfoEmptyAcceptsAllFF(t *testing.T) {
+	// Real ROM SAMDOS-2 SAVE 0xFF-fills FileTypeInfo via HDCLP2
+	// (rom-disasm:22076-22080); observed on the M0 boot disk's slot-4
+	// OUT entry. This is a legitimate "unused" marker — the rule must
+	// not fire when every byte is 0xFF.
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	for i := range dj[0].FileTypeInfo {
+		dj[0].FileTypeInfo[i] = 0xFF
+	}
+	di.WriteFileEntry(dj, 0)
+	findings := checkCodeFileTypeInfoEmpty(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("FileTypeInfo = 0xFF × 11 (ROM SAMDOS-2 convention): %d findings; want 0", len(findings))
 	}
 }

--- a/rules_smoke_test.go
+++ b/rules_smoke_test.go
@@ -4,14 +4,12 @@ import (
 	"testing"
 )
 
-// TestPhase3RegistryGrowth pins the expected rule count once Phase 3
-// is fully implemented. It will fail in Task 1 (only 1 rule registered)
-// and pass once Tasks 2-6 land the remaining 19 rules. This is a
-// regression gate: if any rule is accidentally removed or never
-// registered, this test fails.
-func TestPhase3RegistryGrowth(t *testing.T) {
-	if got := len(Rules()); got != 20 {
-		t.Errorf("len(Rules()) = %d; want 20 (1 smoke + 19 phase-3 rules)", got)
+// TestRegistryGrowth pins the expected total rule count. Update when
+// new rules are added or removed so the test surfaces accidental
+// changes to the registry size.
+func TestRegistryGrowth(t *testing.T) {
+	if got := len(Rules()); got != 35 {
+		t.Errorf("len(Rules()) = %d; want 35 (1 smoke + 19 phase-3 + 15 phase-4 rules)", got)
 	}
 }
 


### PR DESCRIPTION
Phase 4 of `samfile verify` (spec: `docs/specs/2026-05-11-verify-feature-design.md`, plan: `docs/plans/2026-05-12-verify-phase-4-body-header-ftcode.md`). Implements 15 of the catalog's §5 (body-header consistency) and §6 (FT_CODE-specific) rules. After this lands the registry holds 35 rules total (Phase-1 smoke + 19 Phase-3 + 15 Phase-4); file-type rules for FT_SAM_BASIC / FT_NUM_ARRAY / FT_STR_ARRAY / FT_SCREEN / FT_ZX_SNAPSHOT follow in Phase 5.

## Rules added

**§5 body-header byte-mirror rules** (8): `BODY-TYPE-MATCHES-DIR`, `BODY-LENGTHMOD16K-MATCHES-DIR`, `BODY-PAGEOFFSET-MATCHES-DIR`, `BODY-EXEC-DIV16K-MATCHES-DIR`, `BODY-EXEC-MOD16K-LO-MATCHES-DIR`, `BODY-PAGES-MATCHES-DIR`, `BODY-STARTPAGE-MATCHES-DIR`, `BODY-MIRROR-AT-DIR-D3-DB`

**§5 body-header format rules** (3): `BODY-PAGEOFFSET-8000H-FORM`, `BODY-PAGE-LE-31`, `BODY-BYTES-5-6-CANONICAL-FF`

**§6 FT_CODE rules** (4): `CODE-LOAD-ABOVE-ROM`, `CODE-LOAD-FITS-IN-MEMORY`, `CODE-EXEC-WITHIN-LOADED-RANGE`, `CODE-FILETYPEINFO-EMPTY`

Severity distribution: 2 fatal, 3 structural, 7 inconsistency, 3 cosmetic.

## Deliberately deferred

- `BODY-HEADER-AT-FIRST-SECTOR` — parser invariant.
- `CODE-EXEC-FF-DISABLES` — documents `LOAD CODE` behaviour, not a runtime check.

## Architecture

One file per catalog section: `rules_body_header.go` (§5) and `rules_ft_code.go` (§6). Two private helpers in `rules_body_header.go`:

- `bodyHeaderRaw(*DiskImage, *FileEntry) ([9]byte, error)` reads the 9-byte body header at a file's first sector. Used by every §5 rule; isolates the SectorData call so rules don't reach into raw byte I/O directly.
- `bodyDirMirrorFinding(...)` standardises the "body byte X mismatches dir field Y" Finding shape across the 5 single-byte mirror rules.

§6 rules filter on `fe.Type == FT_CODE` at the top of each Check function.

## CLI smoke surfaced two real bugs (fixed in this PR)

The M0 boot disk (`../sam-aarch64/build/test.mgt`) tripped three rules on what was supposed to be a clean disk. Both root causes are documented in the bugfix commit (`0a1e2b4`):

1. **`BODY-EXEC-DIV16K-MATCHES-DIR` (structural) and `BODY-EXEC-MOD16K-LO-MATCHES-DIR` (inconsistency)** were comparing `body[5..6]` against dir's `ExecutionAddress*` for every used file. But `CreateHeader` (samfile.go:921-927) emits `{0xFF, 0xFF}` for body[5..6] on non-FT_CODE files regardless of dir contents, and dir bytes 0xF2-0xF4 are repurposed for BASIC (auto-RUN line number). The mirror only holds for FT_CODE. Both rules now skip non-CODE slots; regression tests pin the skip.

2. **`CODE-FILETYPEINFO-EMPTY` (cosmetic)** expected dir 0xDD-0xE7 to be all zero (samfile's writer convention). But real ROM SAMDOS-2 SAVE 0xFF-fills these 11 bytes via HDCLP2 (rom-disasm:22076-22080), as seen on M0's slot-4 OUT entry. Same root cause as the Phase 2 MGTFlags issue. The rule now accepts both `0x00` (samfile) and `0xFF` (ROM SAVE) as legitimate unused-markers; warns on anything else. Regression test `TestCodeFileTypeInfoEmptyAcceptsAllFF` pins the M0 scenario.

After the fixes, M0 reports `detected dialect: samdos2` with `no findings` — as expected for a known-clean samfile-built disk.

## CLI smoke summary

- **M0 boot disk**: `detected dialect: samdos2`, no findings.
- **`testdata/ETrackerv1.2.mgt`**: 492 findings (173 fatal, 160 structural, 116 inconsistency, 43 cosmetic) — up from Phase 3's 350. The new §5 / §6 rules fire on the ETracker disk's non-standard body headers, which is expected for a music-tracker disk with custom layout.

## Note on `TestCodeLoadAboveROMNegative`

`samfile.FileHeader.Start()`'s `+1` shift makes `Start() < 0x4000` unreachable via any FileEntry field combination. The negative test is `t.Skip`'d with a documentation comment. The rule matches the catalog and runs cleanly; future raw-byte-construction tests may exercise it.

## Test plan

- [x] `go test ./...` — all green (28 positive/negative pairs + 2 BASIC-skip regression tests + 1 ROM-SAVE-FF regression test = 31 active tests, plus `t.Skip` on `TestCodeLoadAboveROMNegative`)
- [x] `go vet ./...` — clean
- [x] CLI smoke against `testdata/ETrackerv1.2.mgt` produces a structurally well-formed report
- [x] CLI smoke against the M0 boot disk reports `samdos2` and **no findings** (post-fix)
- [ ] GitHub Actions CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)