### PR TITLE
verify: corpus-driven reclassification — 17 commits across 3 iterations

### DIFF
--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -459,7 +459,25 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 - What: The count at 0x0B-0x0C must equal the number of sectors
   visited when walking the chain from FirstSector to the (0,0)
   terminator.
-- Severity: structural
+- Severity: structural (iter-3 kept structural and reworded the
+  finding message: the structural tier is "disk-walk invariant;
+  violation produces undefined behaviour or sector reuse" — and
+  samfile's `(*DiskImage).File` at `samfile.go:743-754` reads
+  exactly `fe.Sectors` chunks without consulting the (0,0)
+  terminator, so a too-large `Sectors` causes `File()` to walk
+  past the terminator into another file's chain (garbage reads),
+  while a too-small `Sectors` silently truncates the file. SAMDOS
+  itself ignores `Sectors` on LOAD — `dos`/`dos8` is terminator-
+  driven (`samdos/src/b.s:104-110`) — and increments it only on
+  SAVE (`fnfs` at `samdos/src/c.s:946-948`), so the rule is
+  samfile-consumer-authority not SAMDOS-authority; but the
+  consumer-side "undefined behaviour" is exactly what the
+  structural tier exists to flag. The message is reworded to
+  surface the consumer hazard so a samfile user can see why the
+  finding matters. Corpus evidence: 4,711 fires / 320 disks (40%);
+  291/320 are also in the CROSS-NO-SECTOR-OVERLAP / CHAIN-MATCHES-
+  SAM cluster, 29 fire independently and are exactly the disks
+  where Sectors-vs-chain disagreement is the only signal.)
 - Source authority: samfile-implicit
 - Citation: `samfile.go:743-754` reads `fe.Sectors` chunks and stops:
 

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -895,14 +895,21 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 ### CODE-FILETYPEINFO-EMPTY — Dir 0xDD-0xE7 unused for CODE
 
 - What: For FT_CODE, dir bytes 0xDD-0xE7 (`FileTypeInfo`) are
-  unused. samfile's `AddCodeFile` leaves them at zero.
+  unused. Three conventions are observed:
+  - 0x00 × 11 — samfile's `AddCodeFile` leaves the struct zero-init.
+  - 0xFF × 11 — real ROM SAMDOS-2 SAVE 0xFF-fills via HDCLP2
+    (rom-disasm:22076-22080).
+  - 0x20 — HDR space-fill leakage from `HDCLP` 25-byte
+    names-area fill (rom-disasm:22070-22074); iteration 1 added 0x20
+    after observing 16,727/16,932 (99%) corpus fires on this value.
 - Severity: cosmetic
-- Source authority: samfile-implicit
+- Source authority: samfile-implicit + ROM
 - Citation: `samfile.go:798-827` (`AddCodeFile` does not set
-  `FileTypeInfo`).
+  `FileTypeInfo`); rom-disasm:22070-22080 (HDR space-fill + HDCLP2
+  0xFF-fill).
 - Dialect: all
-- Test sketch: warn if any byte in `dir[0xDD..0xE8]` is non-zero
-  for a CODE file (unlikely; just a sanity check).
+- Test sketch: warn if any byte in `dir[0xDD..0xE8]` is not in
+  {0x00, 0xFF, 0x20} for a CODE file.
 
 ---
 

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -1085,18 +1085,24 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 - Dialect: all
 - Test sketch: `dir[0xDD] in {1, 2, 3, 4}` for FT_SCREEN.
 
-### SCREEN-LENGTH-MATCHES-MODE — Body length matches mode's screen size
+### SCREEN-LENGTH-MATCHES-MODE — Body length within [min, min+512] for the mode
 
-- What: For FT_SCREEN, the body length should match the documented
-  screen size for the given mode: mode 1 = 6912 bytes, mode 2 = 6912,
-  modes 3-4 = 24576 bytes.
+- What: For FT_SCREEN, the body length must be at least the
+  documented screen-data size for the given mode (mode 1/2 = 6912
+  bytes; mode 3/4 = 24576 bytes) and at most that minimum plus 512
+  bytes of slack. ROM SCREEN$ SAVE canonically appends a
+  palette + sysvars trailer (16 bytes of CLUT + LINE/ATTR/state),
+  so real-world MODE 3/4 screens are commonly 24576+41 = 24617
+  bytes; LOAD SCREEN$ ignores the trailer.
 - Severity: structural
 - Source authority: Tech-Manual
-- Citation: Tech Manual modes table.
+- Citation: Tech Manual L2156 ("spare 8K following a MODE 3/4
+  screen"); corpus empirical 75% of fires are 24576+41 = 24617.
 - Dialect: all
-- Test sketch: cross-reference mode byte and `Length()`.
-- Open questions: exact mode/length mapping; needs Tech Manual
-  cross-check at finalisation time.
+- Test sketch: assert `min <= Length() <= min + 512`, where `min`
+  is 6912 for modes 1/2 and 24576 for modes 3/4. (Iteration 1
+  REWORD: previously required strict equality, which fired on
+  every ROM-SAVE screen with a palette trailer.)
 
 ---
 

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -1115,7 +1115,10 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 - What: For an image to be bootable on real SAM hardware, some
   directory entry's FirstSector must be (4, 1) so that the ROM
   BOOTEX reads the right sector at `&8000`.
-- Severity: fatal (bootability)
+- Severity: structural (bootability) — demoted from fatal in iteration
+  1: 10.6% of real-world disks (85/800 in the corpus) are non-bootable
+  archives that load correctly under another boot disk; SAMDOS neither
+  rejects nor corrupts them, so the spec's "fatal" tier is too strong.
 - Source authority: ROM
 - Citation: rom-disasm:20473-20598 (`BOOTEX`):
 

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -309,7 +309,11 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 - Dialect: all
 - Test sketch: after masking flags, type is in {0, 5, 16, 17, 18,
   19, 20}; warn (don't error) on types 1-4, 6-12 (ZX-compat /
-  MasterDOS / SAMDOS-1) and unknown values.
+  MasterDOS / SAMDOS-1) and unknown values. (Iteration 1 FIX:
+  type 0 is the erased-slot sentinel and is now explicitly
+  delegated to DIR-ERASED-IS-ZERO; this rule no longer fires on
+  Type=0, eliminating a 100% double-fire across 2,492 corpus
+  findings.)
 - Open questions: types 1-12 in SAMDOS's DIR table correspond to ZX
   / Plus-D legacy file types. Real-world MGT disks rarely use them.
   Type 6 ("MD.FILE") is MasterDOS; type 8 ("SPECIAL") is opaque. A

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -1135,7 +1135,10 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 
 - What: For ROM BOOTEX to dispatch to the loaded sector, bytes
   256-259 of T4S1 must spell `B O O T` (any case; bit 7 ignored).
-- Severity: fatal (bootability)
+- Severity: structural (bootability) — demoted from fatal in iteration
+  1: 27.2% of real-world disks (218/800) own T4S1 but lack the BOOT
+  signature; these load correctly under another boot disk, so
+  "fatal" is too strong by the spec's definition.
 - Source authority: ROM
 - Citation: rom-disasm:20582-20598 (`BTNOE`/`BTCK`/`BTLY`):
 

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -989,8 +989,10 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
   `sambasic/file.go:21-34` Line.Bytes writes the same way.
 - Dialect: all
 - Test sketch: walk lines from PROG to NVARS; assert each line's
-  length matches its actual size, all line numbers are within
-  documented range (1..16383 for SAM, 1..9999 typical).
+  length matches its actual size, all line numbers are non-zero
+  (1..65535, uint16 BE; widened from 1..16383 in iteration 1 after
+  corpus evidence of legitimate line numbers in the 20000..65000
+  range — `samfile` had a 0x3FFF mask but ROM BASIC does not).
 
 ### BASIC-STARTLINE-FF-DISABLES — ExecutionAddressDiv16K == 0xFF means no auto-RUN
 

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -589,7 +589,13 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 - What: The disk-wide allocation map (bitwise OR of every used
   slot's `SectorAddressMap`) has no overlap — each set bit must
   come from exactly one slot.
-- Severity: fatal
+- Severity: structural (demoted from fatal in iteration 1: SAMDOS's
+  chain walk reads next-link bytes 510-511 of each sector and does
+  not consult the SectorAddressMap, so an overlap-bearing file still
+  LOADs correctly; the hazard is at SAVE time when `fnfs` may
+  re-allocate a "free" sector. Corpus evidence: 162,727 fires / 299
+  disks; sample/audio disks and non-SAMDOS-written disks routinely
+  exhibit shared sectors with no load-time corruption.)
 - Source authority: SAMDOS-code
 - Citation: SAMDOS allocator at `samdos/src/c.s:895-951` (`fnfs`):
   it scans the merged `sam` array (built from every dir entry) for

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -356,14 +356,35 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 ### DIR-ERASED-IS-ZERO — Erased slot is exactly Type==0
 
 - What: A slot with type byte 0 is erased / free. SAMDOS checks this
-  literally; bit 7 + low-5 zero is still erased.
-- Severity: structural
+  literally; bit 7 + low-5 zero is still erased. The rule fires on
+  slots where Type==0 but FirstSector.Track is non-zero — i.e. the
+  type byte says "free" but the filename / chain / SAM are still
+  populated. This is the canonical "DEL/ERASE leaves the file
+  recoverable" archaeological pattern.
+- Severity: inconsistency. The consumer side is well-defined:
+  `fdhf` (c.s:1133-1143) sees `(hl)==0` and treats the slot as
+  free, so the dir walk is not confused. But the orphaned
+  filename / FirstSector / SectorAddressMap disagree with the
+  type byte's "this slot is unused" claim — two views of the
+  same fact disagree (inconsistency), not "disk-walk invariant
+  violated" (structural). 43% of the corpus has at least one
+  such slot — every DEL/ERASE produces one — which is
+  irreconcilable with "structural disk corruption" framing;
+  structural should be reserved for things like CHAIN-NO-CYCLE
+  (3 disks).
 - Source authority: SAMDOS-code + Tech-Manual
 - Citation: `samdos/src/c.s:1133-1143` (`fdhf` — "TEST FOR FREE
   DIRECTORY SPACE"): `ld a,(hl); and a; jr nz,fdhd`.
   Tech Manual L4351-4354.
-- Dialect: all
-- Test sketch: slot is free iff `data[0x00] == 0`.
+- Dialect: all (MasterDOS DEL not independently verified; the
+  43% dialect-uniform fire rate strongly suggests it behaves the
+  same way, but worth a footnote if MasterDOS turns out to zero
+  the entire entry on DEL).
+- Test sketch: a used slot (`FirstSector.Track != 0`) must NOT have
+  `data[0x00] == 0`; if it does, the slot is in the recoverable-
+  DEL'd-file state — fire DIR-ERASED-IS-ZERO. A truly free slot
+  (`Type==0 && FirstSector.Track==0`) is the common case and
+  must not fire.
 
 ### DIR-NAME-PADDING — Filename is 10 bytes, space-padded ASCII
 

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -124,12 +124,25 @@ The gate has two paths:
 1. Requested-exec path (`HDR+HDN+6`): SAVE-time / `LOAD CODE n,...,exec`
    override populated from dir byte 0xF2. If non-FF, take HDLDEX
    immediately.
-2. Loaded-exec path (`HDL+HDN+6`): from the body-header byte 5
-   (SAMDOS's `hd001..` cache → HDL via dschd / hconr). If non-FF, take
+2. Loaded-exec path (`HDL+HDN+6`): populated from SAMDOS's `hd001..`
+   cache, which `gtfle` (c.s:1376-1379) loads from the dir-side
+   9-byte mirror (dir 0xD3-0xDB), then `hconr` (h.s:336-361)
+   reloads from `uifa+*` (also dir-derived). `txhed` (h.s:38-56)
+   then transmits the dir entry into ROM's HDL/HDR area — so the
+   "loaded exec" path is in practice dir-fed, not body-fed.
+   `ldhd` (f.s:494-497) does read 9 bytes from the body via `lbyt`
+   (c.s:557-570) at LOAD time, but `lbyt` returns each byte in `A`
+   without storing it — the call sequence is a skip-past so that
+   subsequent `ldblk` reads start at body byte 9 (payload). The
+   body's leading 9 bytes never feed into HDL. If non-FF, take
    HDLDEX; if FF, RET (no auto-exec).
 
 So the auto-exec is gated on BOTH the directory entry's byte 0xF2 AND
-the body-header's byte 5. Each must be `0xFF` to disable auto-exec.
+the dir-side mirror at 0xD3+5 (the value SAMDOS treats as the
+"loaded exec page"). The body header's byte 5 is decorative on LOAD.
+For "byte-identical to canonical SAVE" purposes the body mirror is
+still worth checking (see BODY-MIRROR-AT-DIR-D3-DB §5), but it's
+not what the ROM auto-exec gate actually reads.
 
 The "low byte of ExecutionAddressMod16K mirrors at body-header byte 6"
 part of PR-12 prose is half-right: body-header bytes 5-6 are the
@@ -660,7 +673,12 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
   PROTECTED bits masked off. (SAMDOS keeps these in sync via
   `svhd` writing the same `hd001` value to dir 0xD3 and body byte
   0; the dir's own type byte is set separately by `ofsm`.)
-- Severity: inconsistency
+- Severity: cosmetic (body mirror is save-time-only; LOAD reads
+  from the dir entry — gtfle → uifa → hconr → ROM HDL/HDR via
+  txhed — and the body's first 9 bytes are skipped past by ldhd
+  without being stored; a body↔dir mismatch has zero load-time
+  consequence. See BODY-MIRROR-AT-DIR-D3-DB §5 for the citation
+  chain.)
 - Source authority: SAMDOS-code
 - Citation: `samdos/src/c.s:1395-1408` (`gtfle`-derived `gtfl1`
   block) and `samdos/src/b.s:255` (`hd001:  defb &13`).
@@ -671,7 +689,8 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 
 - What: Body header `LengthMod16K` (LE 16-bit at bytes 1-2) must
   equal the dir entry's mirrored field at 0xF0-0xF1.
-- Severity: inconsistency
+- Severity: cosmetic (body mirror is save-time-only; LOAD reads
+  from dir via gtfle/hconr — see BODY-MIRROR-AT-DIR-D3-DB).
 - Source authority: SAMDOS-code
 - Citation: `samdos/src/c.s:1376-1379` (`gtfle` reads 9 bytes from
   dir+211 into `hd001..page1` — which IS `hd001/hd0b1/hd0d1/.../
@@ -685,7 +704,8 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 
 - What: Body `PageOffset` (LE 16-bit at bytes 3-4) mirrors dir
   `StartAddressPageOffset` at 0xED-0xEE.
-- Severity: inconsistency
+- Severity: cosmetic (body mirror is save-time-only; LOAD reads
+  from dir via gtfle/hconr — see BODY-MIRROR-AT-DIR-D3-DB).
 - Source authority: SAMDOS-code
 - Citation: same as BODY-LENGTHMOD16K-MATCHES-DIR; the 9-byte
   mirror at dir+211 includes bytes 3-4.
@@ -726,7 +746,8 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 ### BODY-PAGES-MATCHES-DIR — Body byte 7 == dir byte 0xEF
 
 - What: Body `Pages` mirrors dir `Pages` at 0xEF.
-- Severity: inconsistency
+- Severity: cosmetic (body mirror is save-time-only; LOAD reads
+  from dir via gtfle/hconr — see BODY-MIRROR-AT-DIR-D3-DB).
 - Source authority: SAMDOS-code
 - Citation: 9-byte mirror at dir+211 (see PR-12 hypothesis #1).
 - Dialect: all
@@ -738,7 +759,8 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
   Note that only the low 5 bits are functional (page index 0..31);
   bits 5-7 are decorative and may differ between byte-perfect
   ROM-SAVE output and synthetic writers (cf. `sam-stub-audit.md`).
-- Severity: inconsistency
+- Severity: cosmetic (body mirror is save-time-only; LOAD reads
+  from dir via gtfle/hconr — see BODY-MIRROR-AT-DIR-D3-DB).
 - Source authority: SAMDOS-code + samfile-implicit
 - Citation: 9-byte mirror at dir+211. samfile's `Start()`
   masks `(StartPage & 0x1F)+1`:
@@ -756,11 +778,31 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 - What: SAMDOS keeps a verbatim 9-byte body-header cache at dir
   offset 0xD3-0xDB. See §0 for the verification. Byte 0xD2 is
   unused; expect zero.
-- Severity: inconsistency (writer that omits this still works because
-  SAMDOS re-reads from body on next access, but it deviates from
-  canonical SAVE output)
+- Severity: cosmetic. Canonical SAMDOS SAVE writes both sides
+  (svhd at `samdos/src/f.s:462-471` stores `hd001..page1` to dir
+  0xD3-0xDB AND to the file body's leading 9 bytes via `sbyt`),
+  so the mirror IS a real SAVE-time convention. But body bytes
+  0..8 are unused on LOAD: `ldhd` (`samdos/src/f.s:494-497`)
+  calls `lbyt` (`samdos/src/c.s:557-570`) nine times — `lbyt`
+  returns each body byte in `A` *without storing it anywhere* —
+  so `ldhd` only advances the read pointer past the 9-byte body
+  header so subsequent `ldblk` reads start at body byte 9 (the
+  payload). The fields ROM consumes on LOAD all come from the
+  dir entry: `gtfle` (`samdos/src/c.s:1376-1379`) fills the
+  9-byte cache `hd001..page1` and `uifa+*` from dir 0xD3-0xDB
+  and dir 0xEC-0xF1; `hconr` (`samdos/src/h.s:336-361`) reloads
+  `hd001 / page1 / hd0d1 / pges1 / hd0b1` from `uifa+*` (i.e.
+  dir-derived, NOT from the body); `txhed` (`samdos/src/h.s:38-56`)
+  transmits 48 bytes from `difa` (the dir-entry buffer) into
+  ROM's HDL/HDR area. Body bytes 0..8 never enter ROM's view.
+  A writer that omits the mirror produces a disk that loads
+  identically — and 93% of samdos2-written corpus disks do
+  exactly that. The mirror is worth keeping as a "byte-identical
+  to canonical SAMDOS SAVE output" signal, but it is not an
+  integrity indicator.
 - Source authority: SAMDOS-code
-- Citation: §0, `samdos/src/f.s:462-471` + `c.s:1376-1379`.
+- Citation: §0, `samdos/src/f.s:462-471` + `c.s:1376-1379` +
+  `f.s:494-497` + `c.s:557-570` + `h.s:336-361` + `h.s:38-56`.
 - Dialect: all
 - Test sketch: `dir[0xD2] == 0`; `dir[0xD3..0xDC] == body[0..9]`.
 - Open questions: must `dir[0xD2]` be exactly zero, or merely

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -627,13 +627,17 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 - What: The disk-wide allocation map (bitwise OR of every used
   slot's `SectorAddressMap`) has no overlap — each set bit must
   come from exactly one slot.
-- Severity: structural (demoted from fatal in iteration 1: SAMDOS's
-  chain walk reads next-link bytes 510-511 of each sector and does
-  not consult the SectorAddressMap, so an overlap-bearing file still
-  LOADs correctly; the hazard is at SAVE time when `fnfs` may
-  re-allocate a "free" sector. Corpus evidence: 162,727 fires / 299
-  disks; sample/audio disks and non-SAMDOS-written disks routinely
-  exhibit shared sectors with no load-time corruption.)
+- Severity: inconsistency (demoted from fatal→structural→inconsistency
+  across iterations 1-3: SAMDOS LOAD walks the chain via next-link
+  bytes 510-511 and does not consult the SectorAddressMap
+  (`samdos/src/b.s:104-110`); the disagreement is between the merged
+  SAM-map view ("each sector belongs to one file") and the chain-walk
+  view (the LOAD authority), a "two views of the same fact disagree"
+  pattern. The hazard is at SAVE time when `fnfs` may refuse a "free"
+  sector (`samdos/src/c.s:895-951`). Corpus evidence: 162,727 fires /
+  299 disks (37%); sample/audio disks and non-SAMDOS-written disks
+  routinely exhibit shared sectors with no load-time corruption.
+  Follow-up: per-disk summary mode to collapse the per-sector fan-out.)
 - Source authority: SAMDOS-code
 - Citation: SAMDOS allocator at `samdos/src/c.s:895-951` (`fnfs`):
   it scans the merged `sam` array (built from every dir entry) for

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -625,7 +625,8 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 - Citation: `samfile.go:984-987` (`SAMMask` formula). For chains:
   any link `(track, sector)` with `track < 4` would be invalid.
 - Dialect: all
-- Test sketch: every link in every chain has `(track & 0x7F) >= 4`.
+- Test sketch: every link in every chain has `track in {4..79, 128..207}`
+  (i.e. `track < 4` only on side 0; side 1 cylinders 0..3 are data sectors).
 
 ---
 

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -595,7 +595,16 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 
 - What: The set of sectors visited during a chain walk must equal
   the set of bits set in dir bytes 0x0F-0xD1.
-- Severity: structural
+- Severity: inconsistency (demoted in iter-3: SAMDOS LOAD walks the
+  chain via next-link bytes 510-511 (`samdos/src/b.s:104-110`) and
+  never reads the per-slot SectorAddressMap; the chain is the
+  LOAD-time authority. The SAM map is SAVE-side bookkeeping populated
+  by `cfsm`/`fnfs` (`samdos/src/c.s:1306-1343`,
+  `samdos/src/c.s:895-951`). A chain-vs-map disagreement is a
+  writer-tool bug — "two views of the same fact disagree" — not a
+  disk-walk invariant violation. Corpus evidence: 4,886 fires / 316
+  disks (40%); strongly correlated with CROSS-NO-SECTOR-OVERLAP
+  (291/316) and DIR-SECTORS-MATCHES-CHAIN (315/316).)
 - Source authority: SAMDOS-code + samfile-implicit
 - Citation: `samdos/src/c.s:1306-1343` (`cfsm` — Close File Sector
   Map): the allocator-side that writes both the SAM map and the

--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -1012,19 +1012,25 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 - Test sketch: for FT_SAM_BASIC, `dir[0xF2] in {0x00, 0xFF}`; if
   `0x00`, `dir[0xF3..0xF5]` is a valid line number.
 
-### BASIC-STARTLINE-WITHIN-PROG — Auto-RUN line is in the saved program
+### BASIC-STARTLINE-WITHIN-PROG — Auto-RUN line is at or below the highest saved line
 
 - What: If auto-RUN is enabled, the line number at 0xF3-0xF4 should
-  correspond to an actual line number in the program area.
-- Severity: cosmetic (warn-only — auto-RUN of a missing line just
-  errors with "Statement lost", not a corruption)
-- Source authority: empirical-convention
+  be at or below the highest line number in the program area. SAM
+  BASIC's RUN N uses NEXT-LINE-GE semantics (the lookup finds the
+  first line whose number is >= N), so RUN N at or below the lowest
+  saved line is the canonical "start from the beginning" idiom and
+  is not an error — only RUN N above the highest saved line genuinely
+  has no line to run.
+- Severity: cosmetic (warn-only)
+- Source authority: ROM (RUN command's line-lookup semantics)
 - Citation: ROM auto-RUN dispatch via `NEW PPC` sysvar after LOAD;
-  if line doesn't exist, BASIC errors. No code citation enforces
-  pre-LOAD validation.
+  line lookup uses NEXT-LINE-GE not LINE-EQ.
 - Dialect: all
-- Test sketch: walk program, collect line numbers, check
-  `dir[0xF3..0xF5]` is among them.
+- Test sketch: walk program, find the highest line number, warn if
+  `dir[0xF3..0xF5]` is strictly greater than it. (Iteration 1
+  REWORD: previously fired on "line not present in saved program",
+  which mis-categorised the 78% canonical `RUN 1, first-line=10`
+  pattern as a problem; SAM BASIC's RUN tolerates this.)
 
 ### BASIC-MGTFLAGS-20 — MGTFlags is typically 0x20 for BASIC files
 

--- a/docs/notes/corpus-reclassification-2026-05-12.md
+++ b/docs/notes/corpus-reclassification-2026-05-12.md
@@ -1,0 +1,462 @@
+# samfile verify — corpus-driven reclassification
+
+Date: 2026-05-12. Branch: `samfile-corpus-reclass` (16 commits ahead of
+`origin/master`). Author: Claude, three rounds of propose/review/implement.
+
+## TL;DR
+
+We pointed `samfile verify` at a deduplicated corpus of **800 real-world
+SAM disks** (sourced from `~/Downloads/GoodSamC2/` plus scattered local
+disks; deduped by SHA-256 of the 819,200-byte content; format-filtered
+on disk size) and used the resulting fire-rates to reclassify rules
+whose severities were demonstrably miscalibrated. Each candidate change
+was justified against SAMDOS source (`~/git/samdos/src/`), the ROM
+disassembly, the Tech Manual, or the catalog at
+`~/git/samfile-corpus-reclass/docs/disk-validity-rules.md` — never on
+prevalence alone.
+
+The corpus showed three pathological clusters: a single off-by-one mask
+bug producing ~40k false structural findings; a `CROSS-NO-SECTOR-OVERLAP`
+rule producing 162,727 of the 165,620 fatal findings (98% of fatal
+volume) on disks that load fine under SAMDOS; and a six-rule
+"body-header mirror" cluster firing as `inconsistency` on 91–97% of
+every dialect (samdos1, samdos2, masterdos, unknown). Across three
+iterations we landed **16 commits** that net out to:
+
+- **Fatal volume: −98.8%** (165,620 → 1,937)
+- **Disks with no fatal findings: 25.5% → 77.6%**
+- **Disks clean at the default display threshold (no fatal + no
+  structural): 0.1% → 18.6%** (1 → 149 of 800)
+- **Total rule count unchanged at 51** — every change is FIX (3 sites,
+  one mask bug), DEMOTE (10 rules), SCOPE (4 rules), REWORD (4 rules),
+  KEEP (5 rules). No rule was added or removed.
+
+We stopped at iter-3 because every high-fire rule now has a defensible
+classification grounded in SAMDOS source. The 4 follow-up issues we
+identified are catalog corrections and a `CROSS-NO-SECTOR-OVERLAP`
+per-disk summary-mode feature — none of them are severity questions.
+
+---
+
+## The corpus
+
+- **Size**: 800 unique 819,200-byte `.mgt` images (`SELECT COUNT(*) FROM
+  disks` against `~/sam-corpus/findings.db` returns 800).
+- **Sources**: `~/Downloads/GoodSamC2/` (the bulk) plus scattered local
+  disks including the M0 boot disk `~/sam-corpus/disks/test.mgt`.
+- **Filter**: 819,200 bytes after stripping the 22-byte SAD signature
+  header where present. Anything else (.dsk variants, alternate
+  geometries) was excluded.
+- **Dedupe**: SHA-256 of the 819,200-byte content.
+
+### Dialect distribution
+
+| Dialect | Disks |
+|---|---:|
+| unknown | 470 |
+| masterdos | 151 |
+| samdos2 | 114 |
+| samdos1 | 65 |
+
+The 59% "unknown" rate is itself a signal: most disks in the wild
+weren't produced by a single canonical SAMDOS-or-MasterDOS writer; they
+are ROM-SAVE'd or built by third-party tools (Lemmings/Demo packagers,
+sample-disk authors, Chris White's Lemmings tooling, etc.). This is
+the load-bearing fact behind several of the demotes below.
+
+---
+
+## Headline metric table
+
+All four severity columns and the disk-health rows come from
+`~/sam-corpus/findings.db` queries shown in the per-iteration reports
+(`~/sam-corpus/report-iter-{0,1,2,3}.md`).
+
+| Metric | iter-0 (before) | iter-3 (after) | Δ |
+|---|---:|---:|---:|
+| fatal findings | 165,620 | 1,937 | −98.8% |
+| structural findings | 65,254 | 11,532 | −82.3% |
+| inconsistency findings | 42,798 | 172,949 | +304.1% (severity shift) |
+| cosmetic findings | 25,967 | 41,154 | +58.5% (severity shift) |
+| **total findings** | 299,639 | 227,572 | −24.1% |
+| disks with zero findings | 1 (0.1%) | 6 (0.8%) | +5 |
+| disks with no fatal | 204 (25.5%) | 621 (77.6%) | +417 |
+| disks with no fatal + no structural | 1 (0.1%) | 149 (18.6%) | +148 |
+
+The +304%/+58.5% growth on inconsistency/cosmetic is the headline
+*reclassification* effect (severity-only demotes); the −24.1% on total
+volume is the *bug-fix* effect (the side-1 mask FIX and the
+DIR-TYPE-BYTE-IS-KNOWN double-fire FIX). Together they mean the
+default-display output (severity ≥ structural by current convention)
+now shows roughly 1/30th of the noise it did before, mostly comprising
+real load-time hazards rather than mask-bug false positives or
+SAMDOS-canonical conventions that 90%+ of real disks ignore.
+
+---
+
+## Per-iteration summary
+
+### Iter-1 — find the high-volume bugs and miscalibrations (11 commits)
+
+Proposal: `~/sam-corpus/proposal-iter-1.md` (4 FIX, 3 DEMOTE, 4 SCOPE,
+2 REWORD, 2 KEEP, 1 INVESTIGATE). Review: `~/sam-corpus/review-iter-1.md`
+(13 of 15 approved as-is; 2 BODY-EXEC entries had a text inversion that
+landed only as a wording fix — code was sound).
+
+The big-ticket items were the side-agnostic cyl-mask FIX shared by
+`DIR-FIRST-SECTOR-VALID`, `DISK-DIRECTORY-TRACKS`, and
+`CROSS-DIRECTORY-AREA-UNUSED` (`(t & 0x7F) < 4` wrongly excluded side-1
+cylinders 0..3 from the data area — see commit `f619d9a`), and the
+`CROSS-NO-SECTOR-OVERLAP` fatal→structural demote that alone removed
+~163k fatal findings (commit `bff412c`; the rule was tagged fatal but
+SAMDOS LOAD doesn't consult the SectorAddressMap, per
+`~/git/samdos/src/b.s:104-110`). Eight further commits implemented the
+SCOPE/REWORD/DEMOTE entries the reviewer signed off on.
+
+The `BODY-MIRROR-AT-DIR-D3-DB` INVESTIGATE was kept open for iter-2 —
+93% violation across all four dialects pointed to a catalog claim that
+needed source verification, not a code change.
+
+### Iter-2 — body-mirror cluster + DIR-ERASED-IS-ZERO (2 commits)
+
+Proposal: `~/sam-corpus/proposal-iter-2.md` (6 DEMOTE + 1 reword in one
+commit; DIR-ERASED-IS-ZERO DEMOTE + reword in another; 3 INVESTIGATE-
+defer; 1 KEEP). Review: `~/sam-corpus/review-iter-2.md` — same actions
+approved but the proposer's **technical justification for the
+body-mirror cluster demote was inverted**. The fix was a wording rewrite
+in commit `2b8aa1a`, citing the correct LOAD path through
+`gtfle → hconr → txhed` (dir-derived; body bytes 0..8 are skipped by
+`ldhd` and discarded, not authoritative on LOAD).
+
+Both commits landed. The chain-vs-map structural-fan-out cluster
+(`CROSS-NO-SECTOR-OVERLAP`, `DIR-SECTORS-MATCHES-CHAIN`,
+`CHAIN-MATCHES-SAM`) was deferred to iter-3 — demoting it without a
+disk-level summary mode would have left the per-sector fan-out noise
+intact regardless of severity.
+
+### Iter-3 — chain/SAM/Sectors cluster (3 commits)
+
+Proposal: `~/sam-corpus/proposal-iter-3.md` (3 DEMOTE for the deferred
+trio, 2 REWORD bundled, 5 KEEP, 1 INVESTIGATE-defer). Review:
+`~/sam-corpus/review-iter-3.md` — accepted 2 of 3 DEMOTEs but rejected
+the third (`DIR-SECTORS-MATCHES-CHAIN`) on the grounds that the spec's
+`structural` legend at `disk-validity-rules.md:28-34` is broader than
+"SAMDOS-authority-only" (it specifically says "disk-walk invariant;
+violation produces undefined behaviour or sector reuse"), and
+`samfile.go:743-754` reads exactly `fe.Sectors` chunks — too-large
+Sectors reads past the (0,0) terminator into garbage; too-small Sectors
+silently truncates. Both are real load-time consumer corruption.
+
+The implemented split:
+- Commit `86c08d1`: CROSS-NO-SECTOR-OVERLAP DEMOTE + REWORD (structural
+  → inconsistency).
+- Commit `3287b03`: CHAIN-MATCHES-SAM DEMOTE (structural →
+  inconsistency).
+- Commit `f7a1d42`: DIR-SECTORS-MATCHES-CHAIN — message reword only,
+  severity stays structural per reviewer's amendment.
+
+---
+
+## All 16 commits
+
+In landing order (oldest first), with the load-bearing citation each
+change rests on:
+
+1. **`f619d9a`** — verify: FIX DIR-FIRST-SECTOR-VALID /
+   DISK-DIRECTORY-TRACKS / CROSS-DIRECTORY-AREA-UNUSED — drop
+   side-agnostic cylinder mask. Citation: Tech Manual L4340-4343
+   ("first 4 tracks of side 0 are the directory"); `samfile.go:389-394`
+   (range check uses correct ranges).
+2. **`bff412c`** — verify: DEMOTE CROSS-NO-SECTOR-OVERLAP (fatal →
+   structural). Citation: `~/git/samdos/src/b.s:104-110` (LOAD chain
+   walk reads bytes 510-511 only); `~/git/samdos/src/c.s:895-951` (SAVE
+   allocator merges SAM map).
+3. **`6d14929`** — verify: DEMOTE BOOT-OWNER-AT-T4S1 (fatal →
+   structural). Citation: `rules_boot.go:36-39` (rule's own
+   self-acknowledgement); spec §Decisions item 1.
+4. **`ac9d120`** — verify: DEMOTE BOOT-SIGNATURE-AT-256 (fatal →
+   structural). Citation: ROM disasm 20582-20598 (BTCK signature
+   check).
+5. **`365fa7e`** — verify: SCOPE BODY-EXEC-DIV16K-MATCHES-DIR — skip
+   when body[5]==0xFF. Citation: ROM disasm 22467-22484 (auto-exec
+   gate); catalog §BODY-BYTES-5-6-CANONICAL-FF.
+6. **`ffb30da`** — verify: SCOPE BODY-EXEC-MOD16K-LO-MATCHES-DIR — same
+   `body[5]==0xFF` skip. Citation: as #5.
+7. **`07d3dc1`** — verify: SCOPE CODE-FILETYPEINFO-EMPTY — accept 0x20.
+   Citation: ROM disasm 22070-22074 (HDCLP 25-byte space-fill);
+   empirical 99% concentration on 0x20.
+8. **`9a1ae0b`** — verify: SCOPE BASIC-LINE-NUMBER-BE /
+   BASIC-STARTLINE-FF-DISABLES — widen to 1..65535. Citation:
+   `sambasic` parses uint16 line numbers without complaint; corpus
+   evidence of legitimate 20000–65000 line numbers.
+9. **`67491f4`** — verify: REWORD BASIC-STARTLINE-WITHIN-PROG — fire
+   only when auto-RUN line exceeds the highest saved line. Citation:
+   SAM BASIC RUN semantics use NEXT-LINE-GE not LINE-EQ.
+10. **`277aa42`** — verify: REWORD SCREEN-LENGTH-MATCHES-MODE — accept
+    canonical ROM SCREEN$ palette+sysvars trailer. Citation: Tech
+    Manual L2156 ("spare 8K following a MODE 3/4 screen"); empirical
+    75% of fires are 24576+41 = 24617.
+11. **`27216be`** — verify: FIX DIR-TYPE-BYTE-IS-KNOWN — skip Type==0.
+    Citation: catalog `disk-validity-rules.md:310-312` lists type 0 as
+    allowed in the rule's own test sketch; 100% double-fire with
+    DIR-ERASED-IS-ZERO.
+12. **`2b8aa1a`** — verify: DEMOTE body-mirror cluster (6 rules:
+    BODY-MIRROR-AT-DIR-D3-DB, BODY-TYPE-MATCHES-DIR,
+    BODY-LENGTHMOD16K-MATCHES-DIR, BODY-PAGEOFFSET-MATCHES-DIR,
+    BODY-PAGES-MATCHES-DIR, BODY-STARTPAGE-MATCHES-DIR) inconsistency →
+    cosmetic. Citation: `~/git/samdos/src/c.s:1376-1379` (`gtfle`
+    populates 9-byte cache from dir+211); `~/git/samdos/src/h.s:336-361`
+    (`hconr` repopulates from `uifa` = dir-derived);
+    `~/git/samdos/src/f.s:494-497` (`ldhd` reads and discards body
+    bytes 0..8 via `lbyt`); `~/git/samdos/src/h.s:38-56` (`txhed`
+    transmits dir entry to ROM HDR/HDL).
+13. **`6d282a7`** — verify: DEMOTE + REWORD DIR-ERASED-IS-ZERO
+    (structural → inconsistency). Citation: `~/git/samdos/src/c.s:1133-1143`
+    (`fdhf` consumer treats Type==0 as free; orphaned filename/chain
+    are normal DEL/ERASE archaeology).
+14. **`86c08d1`** — verify: DEMOTE + REWORD CROSS-NO-SECTOR-OVERLAP
+    (structural → inconsistency). Citation: as #2, plus the spec's
+    inconsistency legend ("two views of the same fact disagree") fits
+    merged-SAM-map vs per-file chain-walk.
+15. **`3287b03`** — verify: DEMOTE CHAIN-MATCHES-SAM (structural →
+    inconsistency). Citation: `~/git/samdos/src/b.s:104-110` (LOAD
+    never reads per-slot SAM); `~/git/samdos/src/c.s:1306-1343` (`cfsm`
+    is SAVE-side bookkeeping); 99.7% co-firing with
+    DIR-SECTORS-MATCHES-CHAIN.
+16. **`f7a1d42`** — verify: REWORD DIR-SECTORS-MATCHES-CHAIN (severity
+    unchanged at structural; reviewer-amended). Citation:
+    `samfile.go:743-754` (consumer reads exactly `fe.Sectors` chunks
+    and never checks the (0,0) terminator — too-large/too-small
+    Sectors both produce undefined behaviour); spec
+    `docs/disk-validity-rules.md:28-34` structural legend includes
+    "violation produces undefined behaviour or sector reuse", which is
+    broader than SAMDOS-authority-only.
+
+---
+
+## What was deferred and why
+
+Four follow-up issues were filed as INVESTIGATE-defer or noted in
+iteration reviews — none of them are severity questions and none
+require another reclassification loop.
+
+- **CROSS-NO-SECTOR-OVERLAP per-disk summary mode** (iter-2-deferred,
+  carried through iter-3). The rule fires once per overlapping sector,
+  producing 162,727 findings across only 299 disks (mean 544
+  fires/disk; max 1,560 on Comms Loader). After the iter-3 demote to
+  inconsistency this no longer drowns out higher tiers, but the
+  per-sector fan-out is still poor UX. Right shape: one disk-level
+  finding plus per-sector detail behind `--verbose`. This is a feature,
+  not a severity reclassification.
+- **Structural-fan-out follow-up** for CROSS-NO-SECTOR-OVERLAP /
+  DIR-SECTORS-MATCHES-CHAIN / CHAIN-MATCHES-SAM. Iter-2's correlation
+  analysis showed 291/299 overlap-cluster disks also fire
+  DIR-SECTORS-MATCHES-CHAIN and 315/316 fire CHAIN-MATCHES-SAM — i.e.
+  the three rules catch the same writer-side bookkeeping disagreement
+  from three angles. After the summary-mode feature lands, re-measure
+  whether the three rules still provide independent signal on the
+  ~8–29 disks that hit one without the others.
+- **Catalog §0 narrative inversion** (iter-2 reviewer flagged; iter-3
+  INVESTIGATE-defer). The text at `disk-validity-rules.md:113-119`
+  describes the loaded-exec path as "from the body-header byte 5
+  (SAMDOS's `hd001..` cache → HDL via dschd / hconr)" — but `hconr`
+  populates from `uifa+*` (dir-derived), not from the body. This is
+  out of scope for the reclassification work but should be corrected
+  in a separate catalog-hygiene PR. See §"The catalog inversion we
+  found" below.
+- **BODY-EXEC body[5..6] BASIC-mirror investigation** (issue #21
+  referenced in the proposal). Iter-1's BODY-EXEC pair scoped the rule
+  to skip `body[5]==0xFF`; the remaining real-mismatch cases need a
+  follow-up against the ROM RUN/GOTO line-lookup path to confirm
+  whether body bytes 5-6 ever feed BASIC's auto-exec.
+- **`samfile.go:390` debug.PrintStack noise** (issue #19, separate
+  from this work). Noted for completeness; not touched by any commit
+  here.
+
+---
+
+## What we deliberately did NOT change (KEEPs)
+
+Five rules with high fire rates were explicitly kept after analysis
+because their residuals are real:
+
+- **DIR-FIRST-SECTOR-VALID** (723 fires / 157 disks / 19.6%
+  post-iter-1). Iter-1 fixed the mask bug; the remaining fires
+  enumerated in the iter-3 evidence (`track=0x02, sector=4`;
+  `track=0x96, sector=235`; `track=0xff, sector=255`; etc.) are
+  out-of-range first-sector pointers — real corruption.
+- **DISK-SECTOR-RANGE** (688 fires / 153 disks / 19.1%). KEPT in
+  iter-1, iter-2 and iter-3. The (0,0) terminator is special-cased at
+  `rules_disk.go:144-146`; the residual `sector 0x00` /
+  `sector 0x56` / etc. messages are out-of-range chain links.
+- **BASIC-VARS-GAP-INVARIANT** (937 fires / 197 disks / 24.6%). 77%
+  of fires are the cross-dialect signal "boot-classified as masterdos
+  but file written with samdos2 gap size" — exactly what the rule
+  was designed to flag. Already cosmetic; correct tier.
+- **BASIC-LINE-NUMBER-BE** (690 fires / 265 disks / 33.1%
+  post-iter-1). Iter-1 widened the range to 1..65535; residual fires
+  are line=0 (313 of 690 — genuine errors) and parse failures on
+  corrupted programs.
+- **BASIC-STARTLINE-FF-DISABLES** (752 fires / 232 disks / 29.0%).
+  Same family as BASIC-LINE-NUMBER-BE; iter-1's widening took care
+  of the false positives.
+
+---
+
+## Where the reviewer overruled the proposer
+
+Three substantive proposer-vs-reviewer disagreements; in each case the
+code change Pete will see in the PR is what the reviewer recommended,
+not what the proposer originally proposed.
+
+- **Iter-1 BODY-EXEC pair**: the proposer mislabeled the most common
+  firing pattern. The proposal claimed `dir=N, body=0xFF` was the
+  bulk of corpus fires and "the genuinely-inconsistent case" was the
+  inverse. The reviewer (`review-iter-1.md:154-214`) verified against
+  the DB that the largest single bucket was actually
+  `body=0x00, dir=0xff` (727 fires) — a *third* pattern not covered
+  by the proposer's bullets. Net outcome: the code change
+  (`if body[5]==0xFF: skip else compare`) was sound and landed
+  unchanged; only the proposal narrative was reworded before
+  implementation.
+- **Iter-2 body-mirror cluster**: the proposer's claim that "body wins
+  on LOAD because `ldhd` overwrites the dir cache from the body" was
+  **inverted**. The reviewer (`review-iter-2.md:24-95`) verified
+  `~/git/samdos/src/f.s:494-497` directly: `ldhd` loops 9 times
+  calling `lbyt` (`~/git/samdos/src/c.s:557-570`), which reads one
+  byte from the chain-driven disk-buffer and `jp incrpt` — it
+  returns the byte in `A` and does not store it anywhere. So `ldhd`
+  *skips* the body header rather than copying it into the cache. The
+  correct framing is "body bytes 0..8 are unused on LOAD; the dir
+  mirror feeds ROM via `gtfle → hconr → txhed`" (citation chain in
+  the iter-2 review §Per-entry verdict). Same DEMOTE conclusion
+  (inconsistency → cosmetic) but for the opposite reason. This is
+  also what surfaced the §0 catalog-text inversion below.
+- **Iter-3 DIR-SECTORS-MATCHES-CHAIN**: the proposer argued the rule
+  should follow CROSS-NO-SECTOR-OVERLAP and CHAIN-MATCHES-SAM down to
+  inconsistency because the catalog's "Source authority" line says
+  `samfile-implicit` and SAMDOS LOAD doesn't read `fe.Sectors`. The
+  reviewer (`review-iter-3.md:95-211`) pointed out that the spec
+  legend for `structural` at `disk-validity-rules.md:28-34` is broader
+  than the SAMDOS-only framing the proposer imported from `fatal` —
+  the legend specifically says "disk-walk invariant; violation
+  produces undefined behaviour or sector reuse", and `samfile.go`'s
+  count-driven loop (`samfile.go:743-754`) produces undefined
+  behaviour on either side of the disagreement. Net outcome: only
+  the message reword landed (commit `f7a1d42`); severity stayed
+  structural.
+
+---
+
+## The catalog inversion we found
+
+While verifying the iter-2 body-mirror cluster demote, the iter-2
+reviewer's source-trace surfaced a pre-existing inversion in the
+catalog narrative at `disk-validity-rules.md:113-119` (the §0 "PR-12
+hypotheses" verification text). The catalog claims `ldhd` *overwrites*
+the in-RAM `hd001..page1` cache from body bytes — i.e. that the body
+header is read into the cache on LOAD. Source verification shows the
+opposite:
+
+- `~/git/samdos/src/f.s:494-497` (`ldhd`): loops 9 times calling
+  `lbyt`. `lbyt` is at `~/git/samdos/src/c.s:557-570` — it reads one
+  byte from the disk-buffer-via-chain pointer, returns it in `A`, and
+  `jp incrpt`. **It never stores the byte anywhere.** The 9-byte body
+  header is read past, not into the cache.
+- `~/git/samdos/src/h.s:74-90` (`dschd`): called by every LOAD/VERIFY
+  path. Calls `ldhd` first (to advance past the header), then stores
+  caller-provided `hkhl/hkbc/hkde` (BASIC LOAD destination registers
+  captured at the `hook:` entry) into `hd0d1 / pges1 / hd0b1`. **It
+  does not populate `hd001` (type byte) or `page1` (start-page byte)
+  from anywhere — those stay as whatever the dir-side path put there.**
+- `~/git/samdos/src/h.s:336-361` (`hconr`): reloads
+  `hd001 / page1 / hd0d1 / pges1 / hd0b1` from `uifa+*` (dir-derived
+  data populated by `gtfle` at `~/git/samdos/src/c.s:1376-1379` from
+  dir bytes 0xD3-0xDB). The dir mirror is what feeds the cache.
+- `~/git/samdos/src/h.s:38-56` (`txhed`): transmits 48 bytes from
+  `difa` (the dir-entry buffer) into ROM's HDL/HDR area. Body bytes
+  0..8 never enter ROM's view directly.
+
+So on LOAD, **the dir mirror is authoritative** — the body header bytes
+0..8 are SAVE-time decoration. A body↔dir mismatch has zero LOAD-time
+consequence (which is why the body-mirror cluster demoted cleanly to
+cosmetic), but the *reason* is the opposite of what the catalog
+currently says. This inversion was discovered through corpus review —
+the proposer originally walked the wrong direction, and only the
+reviewer's independent source verification caught it. The catalog text
+itself is out of scope for this PR; it's INVESTIGATE-defer #3 in the
+deferred list above.
+
+---
+
+## Final state
+
+- **51 rules registered** (`rules_*.go`, unchanged from iter-0).
+- **M0 boot disk stays clean** (`~/sam-corpus/disks/test.mgt`, samdos2,
+  zero findings). The regression gate held every iteration — every
+  proposal documents an explicit M0-safety analysis (see
+  `proposal-iter-{1,2,3}.md` "Cross-cutting observation: M0 regression
+  analysis" sections), and every iteration verified zero new findings
+  on M0 before remeasuring the corpus.
+- **78% of corpus shows no fatal findings** (621/800, up from 204/800 =
+  25.5%).
+- **18.6% of corpus is clean at the default-display threshold** (no
+  fatal + no structural) — 149/800, up from 1/800 = 0.1%. (The default
+  display threshold in `samfile verify` is currently
+  `severity ≥ structural`; the inconsistency and cosmetic tiers are
+  hidden unless `--verbose` or `--severity` is passed.)
+- **Total volume −24.1%** (299,639 → 227,572), with most of the drop
+  attributable to the two FIX commits (`f619d9a` and `27216be`)
+  removing ~43k false positives rather than the DEMOTEs (which
+  preserve every finding).
+
+Verified against the live DB on disk:
+
+```
+$ sqlite3 ~/sam-corpus/findings.db \
+    "SELECT severity, COUNT(*) FROM findings GROUP BY severity;"
+cosmetic|41154
+fatal|1937
+inconsistency|172949
+structural|11532
+```
+
+---
+
+## Future work
+
+- **Three INVESTIGATE-deferred follow-up issues** (listed in "What was
+  deferred and why" above): CROSS-NO-SECTOR-OVERLAP summary mode;
+  structural-fan-out re-measure post-summary-mode; catalog §0 hconr
+  narrative correction.
+- **Cut samfile 3.1.0** — Pete to do.
+- **Bump sam-aarch64 to samfile 3.1.0** — Pete to do.
+- **Phase 7 onwards is ongoing** — as the corpus grows (more disks,
+  more dialects, more unusual writers) we may surface further
+  reclassifications. The corpus + findings DB are checked into
+  `~/sam-corpus/` so future iterations can re-run the same
+  propose/review/implement loop against an expanded dataset.
+
+---
+
+## Appendix: M0 regression gate
+
+Every iteration's proposal includes an explicit M0 regression analysis
+verifying that none of the proposed changes introduce a finding on
+`~/sam-corpus/disks/test.mgt`. The gate held end-to-end:
+
+- iter-0 M0 finding count: **0**
+- iter-1 M0 finding count: **0** (FIXes widen acceptance; DEMOTEs are
+  severity-only; SCOPEs narrow firing sets; M0's dir layout — slot 0
+  Type=0x13/CODE, FirstSector=(4,1), dir 0xDD-0xE7 all zero, body
+  bytes 0..8 match dir mirror byte-for-byte, no overlapping sectors —
+  satisfies every new constraint).
+- iter-2 M0 finding count: **0** (body-mirror demotes don't fire on M0
+  because M0 IS the canonical mirror disk; DIR-ERASED-IS-ZERO doesn't
+  fire because slot 0 is Type=0x13/CODE).
+- iter-3 M0 finding count: **0** (chain/SAM/Sectors demotes don't fire
+  on M0 because M0 has Sectors=49 matching a 49-sector chain to (0,0),
+  per-slot SAM matching the chain walk, and no overlap).
+
+The gate is reproducible by running the iter-3 `samfile verify` build
+against `~/sam-corpus/disks/test.mgt` directly.

--- a/rules_body_header.go
+++ b/rules_body_header.go
@@ -88,11 +88,21 @@ func checkBodyTypeMatchesDir(ctx *CheckContext) []Finding {
 // (samfile.go:921-927) emits 0xFF for body[5] on every non-CODE
 // file regardless of dir contents. The "mirror" only holds for
 // CODE files where both sides encode the same exec-address.
+//
+// Iteration 1 SCOPE: skip when body[5] == 0xFF. Per the auto-exec
+// gate at rom-disasm:22471-22484, auto-exec is disabled at the body
+// level when body[5] is 0xFF — bytes 5-6 are the canonical
+// "defer to dir" pattern ROM SAVE writes (catalog
+// §BODY-BYTES-5-6-CANONICAL-FF). Whatever dir says in that case is
+// authoritative and not a mismatch. The real-inconsistency cases
+// (`body=N (non-FF), dir=M (FF or different N)`) still fire, e.g.
+// the 727 `body=0x00, dir=0xFF` corpus fires where the body would
+// auto-exec from page 0 even though dir disables auto-exec.
 func init() {
 	Register(Rule{
 		ID:          "BODY-EXEC-DIV16K-MATCHES-DIR",
 		Severity:    SeverityStructural,
-		Description: "FT_CODE body-header ExecutionAddressDiv16K (byte 5) equals dir-entry ExecutionAddressDiv16K",
+		Description: "FT_CODE body-header ExecutionAddressDiv16K (byte 5) equals dir-entry ExecutionAddressDiv16K (skipped when body[5]==0xFF — the canonical 'defer to dir' pattern)",
 		Citation:    "rom-disasm:22471-22484",
 		Check:       checkBodyExecDiv16KMatchesDir,
 	})
@@ -106,6 +116,12 @@ func checkBodyExecDiv16KMatchesDir(ctx *CheckContext) []Finding {
 		}
 		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
 		if err != nil {
+			return
+		}
+		// body[5] == 0xFF is the canonical "defer to dir" pattern that
+		// real ROM SAVE writes; dir is authoritative. Not a real
+		// mismatch regardless of dir's value — suppress.
+		if hdr[5] == 0xFF {
 			return
 		}
 		findings = append(findings, bodyDirMirrorFinding(

--- a/rules_body_header.go
+++ b/rules_body_header.go
@@ -55,10 +55,19 @@ func bodyDirMirrorFinding(
 }
 
 // ----- BODY-TYPE-MATCHES-DIR -----
+// Iteration 2 DEMOTE (inconsistency → cosmetic). The body-header
+// mirror cluster is save-time-only: SAMDOS LOAD reads the dir entry
+// (gtfle c.s:1376-1379 → uifa → hconr h.s:336-361 → ROM HDL/HDR
+// via txhed h.s:38-56), and the body's first 9 bytes are read by
+// ldhd (f.s:494-497) using lbyt (c.s:557-570) — but lbyt returns
+// each byte in A without storing it, so ldhd just skips past the
+// 9-byte body header so payload reads start at body byte 9. The
+// body header never feeds into ROM's view, so a body↔dir mismatch
+// has zero load-time consequence.
 func init() {
 	Register(Rule{
 		ID:          "BODY-TYPE-MATCHES-DIR",
-		Severity:    SeverityInconsistency,
+		Severity:    SeverityCosmetic,
 		Description: "body header Type byte equals directory-entry Type (attribute bits masked)",
 		Citation:    "samdos/src/c.s:1395-1408",
 		Check:       checkBodyTypeMatchesDir,
@@ -73,7 +82,7 @@ func checkBodyTypeMatchesDir(ctx *CheckContext) []Finding {
 			return // §1 rules already report the underlying first-sector problem
 		}
 		findings = append(findings, bodyDirMirrorFinding(
-			"BODY-TYPE-MATCHES-DIR", SeverityInconsistency, "samdos/src/c.s:1395-1408", "type",
+			"BODY-TYPE-MATCHES-DIR", SeverityCosmetic, "samdos/src/c.s:1395-1408", "type",
 			slot, fe.Name.String(),
 			uint8(fe.Type)&0x1F, hdr[0],
 		)...)
@@ -181,10 +190,14 @@ func checkBodyExecMod16KLoMatchesDir(ctx *CheckContext) []Finding {
 }
 
 // ----- BODY-PAGES-MATCHES-DIR -----
+// Iteration 2 DEMOTE (inconsistency → cosmetic). Same family as
+// BODY-TYPE-MATCHES-DIR: body byte 7 is skipped (not stored) by
+// ldhd (f.s:494-497) on LOAD; the dir mirror is what feeds the
+// load path via gtfle/hconr/txhed.
 func init() {
 	Register(Rule{
 		ID:          "BODY-PAGES-MATCHES-DIR",
-		Severity:    SeverityInconsistency,
+		Severity:    SeverityCosmetic,
 		Description: "body header Pages (byte 7) equals dir-entry Pages",
 		Citation:    "samdos/src/c.s:1376-1379",
 		Check:       checkBodyPagesMatchesDir,
@@ -199,7 +212,7 @@ func checkBodyPagesMatchesDir(ctx *CheckContext) []Finding {
 			return
 		}
 		findings = append(findings, bodyDirMirrorFinding(
-			"BODY-PAGES-MATCHES-DIR", SeverityInconsistency, "samdos/src/c.s:1376-1379", "Pages",
+			"BODY-PAGES-MATCHES-DIR", SeverityCosmetic, "samdos/src/c.s:1376-1379", "Pages",
 			slot, fe.Name.String(),
 			fe.Pages, hdr[7],
 		)...)
@@ -208,10 +221,14 @@ func checkBodyPagesMatchesDir(ctx *CheckContext) []Finding {
 }
 
 // ----- BODY-STARTPAGE-MATCHES-DIR -----
+// Iteration 2 DEMOTE (inconsistency → cosmetic). Same family as
+// BODY-TYPE-MATCHES-DIR: body byte 8 is skipped (not stored) by
+// ldhd (f.s:494-497) on LOAD. ROM's StartPage view is loaded from
+// the dir entry via uifa+31 → page1 through hconr (h.s:346-347).
 func init() {
 	Register(Rule{
 		ID:          "BODY-STARTPAGE-MATCHES-DIR",
-		Severity:    SeverityInconsistency,
+		Severity:    SeverityCosmetic,
 		Description: "body header StartPage (byte 8) equals dir-entry StartAddressPage",
 		Citation:    "samdos/src/c.s:1376-1379",
 		Check:       checkBodyStartPageMatchesDir,
@@ -226,7 +243,7 @@ func checkBodyStartPageMatchesDir(ctx *CheckContext) []Finding {
 			return
 		}
 		findings = append(findings, bodyDirMirrorFinding(
-			"BODY-STARTPAGE-MATCHES-DIR", SeverityInconsistency, "samdos/src/c.s:1376-1379", "StartAddressPage",
+			"BODY-STARTPAGE-MATCHES-DIR", SeverityCosmetic, "samdos/src/c.s:1376-1379", "StartAddressPage",
 			slot, fe.Name.String(),
 			fe.StartAddressPage, hdr[8],
 		)...)
@@ -235,10 +252,14 @@ func checkBodyStartPageMatchesDir(ctx *CheckContext) []Finding {
 }
 
 // ----- BODY-LENGTHMOD16K-MATCHES-DIR -----
+// Iteration 2 DEMOTE (inconsistency → cosmetic). Same family as
+// BODY-TYPE-MATCHES-DIR: body bytes 1-2 are skipped (not stored)
+// by ldhd (f.s:494-497) on LOAD; the dir-side LengthMod16K is what
+// the load path uses.
 func init() {
 	Register(Rule{
 		ID:          "BODY-LENGTHMOD16K-MATCHES-DIR",
-		Severity:    SeverityInconsistency,
+		Severity:    SeverityCosmetic,
 		Description: "body header LengthMod16K (bytes 1-2 LE) equals dir-entry LengthMod16K",
 		Citation:    "samdos/src/c.s:1376-1379",
 		Check:       checkBodyLengthMod16KMatchesDir,
@@ -256,7 +277,7 @@ func checkBodyLengthMod16KMatchesDir(ctx *CheckContext) []Finding {
 		if actual != fe.LengthMod16K {
 			findings = append(findings, Finding{
 				RuleID:   "BODY-LENGTHMOD16K-MATCHES-DIR",
-				Severity: SeverityInconsistency,
+				Severity: SeverityCosmetic,
 				Location: SlotLocation(slot, fe.Name.String()),
 				Message:  fmt.Sprintf("body LengthMod16K = 0x%04x but dir says 0x%04x", actual, fe.LengthMod16K),
 				Citation: "samdos/src/c.s:1376-1379",
@@ -267,10 +288,14 @@ func checkBodyLengthMod16KMatchesDir(ctx *CheckContext) []Finding {
 }
 
 // ----- BODY-PAGEOFFSET-MATCHES-DIR -----
+// Iteration 2 DEMOTE (inconsistency → cosmetic). Same family as
+// BODY-TYPE-MATCHES-DIR: body bytes 3-4 are skipped (not stored)
+// by ldhd (f.s:494-497) on LOAD. Dir 0xED-0xEE is what hconr
+// (h.s:349-350) populates hd0d1 from on the load path.
 func init() {
 	Register(Rule{
 		ID:          "BODY-PAGEOFFSET-MATCHES-DIR",
-		Severity:    SeverityInconsistency,
+		Severity:    SeverityCosmetic,
 		Description: "body header PageOffset (bytes 3-4 LE) equals dir-entry StartAddressPageOffset",
 		Citation:    "samdos/src/c.s:1376-1379",
 		Check:       checkBodyPageOffsetMatchesDir,
@@ -288,7 +313,7 @@ func checkBodyPageOffsetMatchesDir(ctx *CheckContext) []Finding {
 		if actual != fe.StartAddressPageOffset {
 			findings = append(findings, Finding{
 				RuleID:   "BODY-PAGEOFFSET-MATCHES-DIR",
-				Severity: SeverityInconsistency,
+				Severity: SeverityCosmetic,
 				Location: SlotLocation(slot, fe.Name.String()),
 				Message:  fmt.Sprintf("body PageOffset = 0x%04x but dir says 0x%04x", actual, fe.StartAddressPageOffset),
 				Citation: "samdos/src/c.s:1376-1379",
@@ -299,10 +324,26 @@ func checkBodyPageOffsetMatchesDir(ctx *CheckContext) []Finding {
 }
 
 // ----- BODY-MIRROR-AT-DIR-D3-DB -----
+// Iteration 2 DEMOTE (inconsistency → cosmetic). svhd (f.s:462-471)
+// writes the same 9 bytes to dir+0xD3 AND to the body header on
+// SAVE, so the mirror IS canonical SAVE output. But on LOAD the
+// body header bytes 0..8 are unused: ldhd (f.s:494-497) calls lbyt
+// (c.s:557-570) which returns each body byte in A *without storing
+// it anywhere* — ldhd simply advances the read pointer past the
+// 9-byte body header so subsequent ldblk reads start at body byte
+// 9 (the payload). Everything ROM sees on LOAD is dir-derived:
+// gtfle (c.s:1376-1379) fills the in-RAM cache and uifa from the
+// dir entry, hconr (h.s:336-361) reloads hd001/page1/hd0d1/pges1/
+// hd0b1 from uifa+* (dir-derived) — not from the body — and txhed
+// (h.s:38-56) transmits 48 bytes from difa (the dir-entry buffer)
+// into ROM's HDL/HDR area. So a body↔dir mismatch in bytes 0..8
+// has zero load-time consequence; only the dir side feeds into the
+// load path. 93% of samdos2-written disks omit the mirror, which
+// is irreconcilable with "buggy writer" framing.
 func init() {
 	Register(Rule{
 		ID:          "BODY-MIRROR-AT-DIR-D3-DB",
-		Severity:    SeverityInconsistency,
+		Severity:    SeverityCosmetic,
 		Description: "dir bytes 0xD3..0xDB mirror body header bytes 0..8 (and dir byte 0xD2 is 0)",
 		Citation:    "samdos/src/f.s:462-471",
 		Check:       checkBodyMirrorAtDirD3DB,
@@ -320,7 +361,7 @@ func checkBodyMirrorAtDirD3DB(ctx *CheckContext) []Finding {
 		if fe.MGTFutureAndPast[0] != 0 {
 			findings = append(findings, Finding{
 				RuleID:   "BODY-MIRROR-AT-DIR-D3-DB",
-				Severity: SeverityInconsistency,
+				Severity: SeverityCosmetic,
 				Location: SlotLocation(slot, fe.Name.String()),
 				Message:  fmt.Sprintf("dir byte 0xD2 (MGTFutureAndPast[0]) = 0x%02x but should be 0", fe.MGTFutureAndPast[0]),
 				Citation: "samdos/src/f.s:462-471",
@@ -331,7 +372,7 @@ func checkBodyMirrorAtDirD3DB(ctx *CheckContext) []Finding {
 			if fe.MGTFutureAndPast[1+i] != hdr[i] {
 				findings = append(findings, Finding{
 					RuleID:   "BODY-MIRROR-AT-DIR-D3-DB",
-					Severity: SeverityInconsistency,
+					Severity: SeverityCosmetic,
 					Location: SlotLocation(slot, fe.Name.String()),
 					Message: fmt.Sprintf("dir byte 0x%02x (MGTFutureAndPast[%d]) = 0x%02x but body byte %d = 0x%02x",
 						0xD3+i, 1+i, fe.MGTFutureAndPast[1+i], i, hdr[i]),

--- a/rules_body_header.go
+++ b/rules_body_header.go
@@ -138,11 +138,18 @@ func checkBodyExecDiv16KMatchesDir(ctx *CheckContext) []Finding {
 // For non-CODE files, dir's ExecutionAddressMod16K holds the auto-RUN
 // line (BASIC) or other type-specific data while body[6] is always
 // 0xFF (CreateHeader's non-FT_CODE default).
+//
+// Iteration 1 SCOPE: skip when body[5] == 0xFF. When auto-exec is
+// disabled at the body level (body[5]==0xFF — the canonical
+// "defer to dir" pattern per BODY-EXEC-DIV16K-MATCHES-DIR), the
+// body's byte 6 (lo of mod16K) is meaningless and any value is
+// allowed. Only fire the comparison when the body genuinely encodes
+// an exec address.
 func init() {
 	Register(Rule{
 		ID:          "BODY-EXEC-MOD16K-LO-MATCHES-DIR",
 		Severity:    SeverityInconsistency,
-		Description: "FT_CODE body-header ExecutionAddressMod16KLo (byte 6) equals low byte of dir-entry ExecutionAddressMod16K",
+		Description: "FT_CODE body-header ExecutionAddressMod16KLo (byte 6) equals low byte of dir-entry ExecutionAddressMod16K (skipped when body[5]==0xFF — body byte 6 is meaningless under the 'defer to dir' pattern)",
 		Citation:    "rom-disasm:22472",
 		Check:       checkBodyExecMod16KLoMatchesDir,
 	})
@@ -156,6 +163,12 @@ func checkBodyExecMod16KLoMatchesDir(ctx *CheckContext) []Finding {
 		}
 		hdr, err := bodyHeaderRaw(ctx.Disk, fe)
 		if err != nil {
+			return
+		}
+		// When body[5]==0xFF, auto-exec is disabled at the body level
+		// and byte 6 (lo of mod16K) is meaningless — its value is not
+		// a mismatch with dir, just an undefined byte. Suppress.
+		if hdr[5] == 0xFF {
 			return
 		}
 		findings = append(findings, bodyDirMirrorFinding(

--- a/rules_body_header_test.go
+++ b/rules_body_header_test.go
@@ -80,13 +80,53 @@ func TestBodyExecMod16KLoMatchesDirPositive(t *testing.T) {
 
 func TestBodyExecMod16KLoMatchesDirNegative(t *testing.T) {
 	di, _ := cleanSingleFileDisk(t, "TEST", 100)
-	// Dir's ExecutionAddressMod16K low byte is 0xFF for no-exec; 0xAA differs.
+	// Iteration 1 SCOPE: the rule now skips when body[5]==0xFF (the
+	// "defer to dir" pattern). To make the rule fire, we must first
+	// take body[5] out of the canonical 0xFF — patching body[5] to
+	// 0x7E also creates a real exec-address-bearing body. Then
+	// patching body[6] alone disagrees with dir's mod16K low byte
+	// (still 0xFF for the no-auto-exec dir).
+	mutateFirstSectorByte(t, di, 5, 0x7E)
 	mutateFirstSectorByte(t, di, 6, 0xAA)
 	findings := checkBodyExecMod16KLoMatchesDir(&CheckContext{
 		Disk: di, Journal: di.DiskJournal(),
 	})
 	if len(findings) != 1 || findings[0].RuleID != "BODY-EXEC-MOD16K-LO-MATCHES-DIR" {
 		t.Fatalf("got %d findings, first=%+v; want 1 BODY-EXEC-MOD16K-LO-MATCHES-DIR", len(findings), findings)
+	}
+}
+
+func TestBodyExecMod16KLoMatchesDirSkipsWhenBody5IsFF(t *testing.T) {
+	// Iteration 1 SCOPE regression test: when body[5]==0xFF (the
+	// canonical "defer to dir" pattern), body[6] is meaningless and
+	// the rule must not fire even when body[6] differs from dir's
+	// mod16K low byte.
+	di, _ := cleanSingleFileDisk(t, "TEST", 100)
+	// body[5] is already 0xFF from AddCodeFile; patch only body[6].
+	mutateFirstSectorByte(t, di, 6, 0xAA)
+	findings := checkBodyExecMod16KLoMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("body[5]=0xFF, body[6]=0xAA: %d findings; want 0 (rule must skip when body[5]==0xFF)", len(findings))
+	}
+}
+
+func TestBodyExecDiv16KMatchesDirSkipsWhenBody5IsFF(t *testing.T) {
+	// Iteration 1 SCOPE regression test: when body[5]==0xFF (the
+	// canonical "defer to dir" pattern ROM SAVE writes), the rule
+	// must not fire regardless of dir's value — dir is authoritative
+	// and the body is intentionally signalling "use dir".
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	// Set dir's ExecutionAddressDiv16K to a non-FF value, leaving
+	// body[5] at 0xFF (samfile's default).
+	dj[0].ExecutionAddressDiv16K = 0x05
+	di.WriteFileEntry(dj, 0)
+	findings := checkBodyExecDiv16KMatchesDir(&CheckContext{
+		Disk: di, Journal: di.DiskJournal(),
+	})
+	if len(findings) != 0 {
+		t.Errorf("body[5]=0xFF, dir=0x05: %d findings; want 0 (canonical defer-to-dir pattern)", len(findings))
 	}
 }
 

--- a/rules_boot.go
+++ b/rules_boot.go
@@ -34,13 +34,15 @@ func bootSlot(dj *DiskJournal) (slot int, fe *FileEntry, found bool) {
 // Fires on a single disk-wide finding when no used slot owns T4S1.
 //
 // Note: data-only / archive disks legitimately have no boot file; this
-// rule's "fatal" severity flags non-bootability, not corruption.
-// Phase 7's corpus-validation pass may demote to cosmetic if archive
-// disks dominate the corpus.
+// rule flags non-bootability, not corruption. Iteration 1 corpus
+// evidence (85 fires / 85 disks = 10.6%) confirmed the rule's own
+// caveat: a non-bootable archive disk is neither rejected nor
+// corrupted by SAMDOS once loaded under another boot disk, so the
+// catalog severity is structural (bootability), not fatal.
 func init() {
 	Register(Rule{
 		ID:          "BOOT-OWNER-AT-T4S1",
-		Severity:    SeverityFatal,
+		Severity:    SeverityStructural,
 		Description: "some used directory entry has FirstSector (4, 1) so the disk is bootable on SAM hardware",
 		Citation:    "rom-disasm:20473-20598",
 		Check:       checkBootOwnerAtT4S1,
@@ -53,7 +55,7 @@ func checkBootOwnerAtT4S1(ctx *CheckContext) []Finding {
 	}
 	return []Finding{{
 		RuleID:   "BOOT-OWNER-AT-T4S1",
-		Severity: SeverityFatal,
+		Severity: SeverityStructural,
 		Location: DiskWideLocation(),
 		Message:  "no used slot has FirstSector (track 4, sector 1); disk is not bootable on real SAM hardware",
 		Citation: "rom-disasm:20473-20598",

--- a/rules_boot.go
+++ b/rules_boot.go
@@ -68,10 +68,16 @@ func checkBootOwnerAtT4S1(ctx *CheckContext) []Finding {
 // (the ROM compares (disk_byte XOR expected_byte) AND 0x5F per
 // rom-disasm:20582-20598). Only applies when a boot owner exists;
 // BOOT-OWNER-AT-T4S1 reports the no-owner case separately.
+//
+// Iteration 1 corpus evidence: 218 fires / 218 disks = 27.2%. Like
+// BOOT-OWNER-AT-T4S1, this flags non-bootability rather than data
+// corruption — SAMDOS neither rejects nor mangles a disk whose T4S1
+// lacks the "BOOT" signature. Severity is therefore structural
+// (bootability), not fatal.
 func init() {
 	Register(Rule{
 		ID:          "BOOT-SIGNATURE-AT-256",
-		Severity:    SeverityFatal,
+		Severity:    SeverityStructural,
 		Description: "T4S1 bytes 256-259 spell \"BOOT\" (case-insensitive, bit 7 ignored)",
 		Citation:    "rom-disasm:20582-20598",
 		Check:       checkBootSignatureAt256,
@@ -95,7 +101,7 @@ func checkBootSignatureAt256(ctx *CheckContext) []Finding {
 		if (sd[256+i]^expected[i])&0x5F != 0 {
 			return []Finding{{
 				RuleID:   "BOOT-SIGNATURE-AT-256",
-				Severity: SeverityFatal,
+				Severity: SeverityStructural,
 				Location: SlotLocation(slot, fe.Name.String()),
 				Message:  fmt.Sprintf("T4S1 boot signature mismatch at byte %d: got 0x%02x, expected 0x%02x (masked with 0x5F)", 256+i, sd[256+i], expected[i]),
 				Citation: "rom-disasm:20582-20598",

--- a/rules_boot_test.go
+++ b/rules_boot_test.go
@@ -41,8 +41,8 @@ func TestBootOwnerAtT4S1Negative(t *testing.T) {
 	if len(findings) != 1 || findings[0].RuleID != "BOOT-OWNER-AT-T4S1" {
 		t.Fatalf("got %d findings, first=%+v; want 1 BOOT-OWNER-AT-T4S1", len(findings), findings)
 	}
-	if findings[0].Severity != SeverityFatal {
-		t.Errorf("Severity = %v; want fatal", findings[0].Severity)
+	if findings[0].Severity != SeverityStructural {
+		t.Errorf("Severity = %v; want structural", findings[0].Severity)
 	}
 }
 

--- a/rules_chain.go
+++ b/rules_chain.go
@@ -139,7 +139,7 @@ func checkChainNoCycle(ctx *CheckContext) []Finding {
 func init() {
 	Register(Rule{
 		ID:          "CHAIN-MATCHES-SAM",
-		Severity:    SeverityStructural,
+		Severity:    SeverityInconsistency,
 		Description: "the set of sectors walked by the chain equals the bits set in the SectorAddressMap",
 		Citation:    "samdos/src/c.s:1306-1343",
 		Check:       checkChainMatchesSAM,
@@ -163,7 +163,7 @@ func checkChainMatchesSAM(ctx *CheckContext) []Finding {
 			if !mapSet[s] {
 				findings = append(findings, Finding{
 					RuleID:   "CHAIN-MATCHES-SAM",
-					Severity: SeverityStructural,
+					Severity: SeverityInconsistency,
 					Location: SlotLocation(slot, fe.Name.String()),
 					Message:  fmt.Sprintf("sector %v is visited by the chain but not set in the SectorAddressMap", s),
 					Citation: "samdos/src/c.s:1306-1343",
@@ -175,7 +175,7 @@ func checkChainMatchesSAM(ctx *CheckContext) []Finding {
 			if !walked[s] {
 				findings = append(findings, Finding{
 					RuleID:   "CHAIN-MATCHES-SAM",
-					Severity: SeverityStructural,
+					Severity: SeverityInconsistency,
 					Location: SlotLocation(slot, fe.Name.String()),
 					Message:  fmt.Sprintf("sector %v is set in the SectorAddressMap but not visited by the chain", s),
 					Citation: "samdos/src/c.s:1306-1343",

--- a/rules_cross.go
+++ b/rules_cross.go
@@ -14,7 +14,7 @@ import (
 func init() {
 	Register(Rule{
 		ID:          "CROSS-NO-SECTOR-OVERLAP",
-		Severity:    SeverityStructural,
+		Severity:    SeverityInconsistency,
 		Description: "no two used files claim the same data sector",
 		Citation:    "samdos/src/c.s:895-951",
 		Check:       checkCrossNoSectorOverlap,
@@ -42,9 +42,9 @@ func checkCrossNoSectorOverlap(ctx *CheckContext) []Finding {
 		s := sec
 		findings = append(findings, Finding{
 			RuleID:   "CROSS-NO-SECTOR-OVERLAP",
-			Severity: SeverityStructural,
+			Severity: SeverityInconsistency,
 			Location: SectorLocation(claims[0].Slot, claims[0].Name, &s, -1),
-			Message: fmt.Sprintf("sector %v is claimed by %d slots (first: %d %q, second: %d %q)",
+			Message: fmt.Sprintf("sector %v is claimed by %d slots (first: %d %q, second: %d %q) — SAMDOS LOAD reads each chain independently so files load correctly, but SAVE on this disk may refuse free sectors",
 				s, len(claims), claims[0].Slot, claims[0].Name, claims[1].Slot, claims[1].Name),
 			Citation: "samdos/src/c.s:895-951",
 		})

--- a/rules_cross.go
+++ b/rules_cross.go
@@ -14,7 +14,7 @@ import (
 func init() {
 	Register(Rule{
 		ID:          "CROSS-NO-SECTOR-OVERLAP",
-		Severity:    SeverityFatal,
+		Severity:    SeverityStructural,
 		Description: "no two used files claim the same data sector",
 		Citation:    "samdos/src/c.s:895-951",
 		Check:       checkCrossNoSectorOverlap,
@@ -42,7 +42,7 @@ func checkCrossNoSectorOverlap(ctx *CheckContext) []Finding {
 		s := sec
 		findings = append(findings, Finding{
 			RuleID:   "CROSS-NO-SECTOR-OVERLAP",
-			Severity: SeverityFatal,
+			Severity: SeverityStructural,
 			Location: SectorLocation(claims[0].Slot, claims[0].Name, &s, -1),
 			Message: fmt.Sprintf("sector %v is claimed by %d slots (first: %d %q, second: %d %q)",
 				s, len(claims), claims[0].Slot, claims[0].Name, claims[1].Slot, claims[1].Name),

--- a/rules_cross.go
+++ b/rules_cross.go
@@ -102,7 +102,9 @@ func checkCrossDirectoryAreaUnused(ctx *CheckContext) []Finding {
 	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
 		result := walkChain(ctx.Disk, fe.FirstSector)
 		for _, st := range result.Steps {
-			if (st.Sector.Track & 0x7F) < 4 {
+			// Directory area is side 0 cylinders 0..3 only (Tech Manual L4340-4343);
+			// side 1 cylinders 0..3 (tracks 0x80..0x83) are valid data sectors.
+			if st.Sector.Track < 4 {
 				s := st.Sector
 				findings = append(findings, Finding{
 					RuleID:   "CROSS-DIRECTORY-AREA-UNUSED",

--- a/rules_directory.go
+++ b/rules_directory.go
@@ -64,16 +64,33 @@ func checkDirTypeByteIsKnown(ctx *CheckContext) []Finding {
 }
 
 // ----- DIR-ERASED-IS-ZERO -----
-// Used() already encodes the rule but the catalog asks us to check the
-// inverse statement: any slot whose raw Type byte is exactly 0x00 but
-// whose other fields look populated (FirstSector non-zero) is suspicious.
-// Phase 3 implements only the forward check: a used slot must NOT have
-// Type == 0. (Empty Type 0 + Track 0 = legitimately free, which is the
-// common case.)
+// Iteration 2 DEMOTE + REWORD (structural → inconsistency). The rule
+// fires on slots where the type byte is 0 (so fdhf at c.s:1133-1143
+// treats it as free) but FirstSector.Track is non-zero (so name /
+// chain / SAM are still populated). That's the canonical
+// "DEL/ERASE leaves the file recoverable" archaeology: SAMDOS DEL
+// (and ROM ERASE) zero only the type byte, leaving the rest of the
+// dir entry intact. SAMDOS treats the slot as free per fdhf, so the
+// dir walk is well-defined — but the orphaned filename + chain
+// disagree with the type byte's "this slot is unused" claim. That's
+// "two views of the same fact disagree" → inconsistency, not
+// "disk-walk invariant violated" → structural.
+//
+// 43% of the corpus has at least one such slot. Keeping it at
+// structural drowns out genuine structural corruption (e.g.
+// CHAIN-NO-CYCLE, 3 disks).
+//
+// The message text is also reworded: the previous "used slot"
+// framing was self-contradictory (Used() returns true here, but
+// SAMDOS itself treats the slot as free), and obscured the
+// archaeological pattern. The new wording names the actual
+// signature ("type byte 0x00 (erased) but filename/chain are still
+// populated") and labels the pattern ("probably a DEL'd file with
+// recoverable header").
 func init() {
 	Register(Rule{
 		ID:          "DIR-ERASED-IS-ZERO",
-		Severity:    SeverityStructural,
+		Severity:    SeverityInconsistency,
 		Description: "a used directory slot has a non-zero type byte",
 		Citation:    "samdos/src/c.s:1133-1143",
 		Check:       checkDirErasedIsZero,
@@ -86,9 +103,9 @@ func checkDirErasedIsZero(ctx *CheckContext) []Finding {
 		if uint8(fe.Type) == 0 {
 			findings = append(findings, Finding{
 				RuleID:   "DIR-ERASED-IS-ZERO",
-				Severity: SeverityStructural,
+				Severity: SeverityInconsistency,
 				Location: SlotLocation(slot, fe.Name.String()),
-				Message:  "used slot has type byte 0x00, which is the erased-slot sentinel",
+				Message:  "slot has type byte 0x00 (erased) but filename/chain are still populated (probably a DEL'd file with recoverable header)",
 				Citation: "samdos/src/c.s:1133-1143",
 			})
 		}

--- a/rules_directory.go
+++ b/rules_directory.go
@@ -169,9 +169,11 @@ func checkDirFirstSectorValid(ctx *CheckContext) []Finding {
 		fs := fe.FirstSector
 		t := fs.Track
 		s := fs.Sector
-		// Side bit (0x80) is informational; mask it off for the cylinder check.
-		cyl := t & 0x7F
-		validTrack := (t < 80 || (t >= 128 && t < 208)) && cyl >= 4
+		// Directory area is side 0 cylinders 0..3 only (Tech Manual L4340-4343);
+		// side 1 cylinders 0..3 (tracks 0x80..0x83) are valid data sectors.
+		// Side 0 (0x00..0x4F): cylinders 0..3 are the directory area, 4..79 are data.
+		// Side 1 (0x80..0xCF): all 80 cylinders are data.
+		validTrack := (t >= 4 && t < 80) || (t >= 128 && t < 208)
 		validSector := s >= 1 && s <= 10
 		if !validTrack || !validSector {
 			findings = append(findings, Finding{

--- a/rules_directory.go
+++ b/rules_directory.go
@@ -235,7 +235,7 @@ func checkDirSectorsMatchesChain(ctx *CheckContext) []Finding {
 				RuleID:   "DIR-SECTORS-MATCHES-CHAIN",
 				Severity: SeverityStructural,
 				Location: SlotLocation(slot, fe.Name.String()),
-				Message:  fmt.Sprintf("dir Sectors=%d, but chain walk visited %d sectors", fe.Sectors, count),
+				Message:  fmt.Sprintf("samfile reads exactly fe.Sectors=%d chunks; chain walk visited %d sectors to the (0,0) terminator — File() returns garbage past the chain end or silently truncates depending on direction", fe.Sectors, count),
 				Citation: "samfile.go:743-754",
 			})
 		}

--- a/rules_directory.go
+++ b/rules_directory.go
@@ -41,6 +41,15 @@ func checkDirTypeByteIsKnown(ctx *CheckContext) []Finding {
 	var findings []Finding
 	forEachUsedSlot(ctx, func(slot int, fe *FileEntry) {
 		t := uint8(fe.Type) & 0x1F
+		// Iteration 1 FIX: type byte 0 is the erased-slot sentinel
+		// and is handled (with the structural severity it deserves)
+		// by DIR-ERASED-IS-ZERO. The catalog's test sketch explicitly
+		// lists 0 in the accepted set, so this rule should not also
+		// fire on it. Skipping here removes a 100% double-fire across
+		// 2,492 corpus findings.
+		if t == 0 {
+			return
+		}
 		if !dirKnownTypes[t] {
 			findings = append(findings, Finding{
 				RuleID:   "DIR-TYPE-BYTE-IS-KNOWN",

--- a/rules_directory_test.go
+++ b/rules_directory_test.go
@@ -12,18 +12,30 @@ func TestDirTypeByteIsKnownPositive(t *testing.T) {
 	}
 }
 
-func TestDirTypeByteIsKnownNegative(t *testing.T) {
+// (Previously: TestDirTypeByteIsKnownNegative used FileType(0) to
+// trigger the rule. Iteration 1 FIX explicitly skips Type==0
+// because DIR-ERASED-IS-ZERO handles that condition with
+// structural severity. Under the new behaviour the rule is
+// effectively unreachable via the in-memory builder: every
+// FileType that passes FileEntry.Used() — i.e. doesn't render as
+// `UNKNOWN (N)` via String() — has its low-5 bits already in
+// dirKnownTypes. The rule fires on raw corpus disks whose type
+// byte was hand-written. TestDirTypeByteIsKnownSkipsErased below
+// covers the FIX itself.)
+
+func TestDirTypeByteIsKnownSkipsErased(t *testing.T) {
+	// Iteration 1 FIX regression test: type byte 0 is the erased-slot
+	// sentinel and is handled by DIR-ERASED-IS-ZERO at structural
+	// severity. DIR-TYPE-BYTE-IS-KNOWN must not also fire on it
+	// (previously double-fired across 2,492 corpus findings).
 	di, dj := cleanSingleFileDisk(t, "TEST", 100)
-	// FileType(7) makes Used() return false (String()="UNKNOWN (7)"), so use
-	// FileType(0) = FT_ERASED instead: String()="Erased" passes Used(), but
-	// uint8(0)&0x1F = 0 is not in dirKnownTypes, so the rule fires.
 	dj[0].Type = FileType(0)
 	di.WriteFileEntry(dj, 0)
 	findings := checkDirTypeByteIsKnown(&CheckContext{
 		Disk: di, Journal: di.DiskJournal(),
 	})
-	if len(findings) != 1 || findings[0].RuleID != "DIR-TYPE-BYTE-IS-KNOWN" {
-		t.Fatalf("got %d findings, first=%+v; want 1 DIR-TYPE-BYTE-IS-KNOWN", len(findings), findings)
+	if len(findings) != 0 {
+		t.Errorf("Type=0 (erased sentinel): %d findings; want 0 (DIR-ERASED-IS-ZERO handles this)", len(findings))
 	}
 }
 

--- a/rules_disk.go
+++ b/rules_disk.go
@@ -79,7 +79,10 @@ func checkDiskDirectoryTracks(ctx *CheckContext) []Finding {
 		if ref.IsTerminator {
 			continue // (0, 0) terminator is allowed even though Track=0 is in [0..3]
 		}
-		if (ref.Sector.Track & 0x7F) < 4 {
+		// Directory area is side 0 cylinders 0..3 only (Tech Manual L4340-4343);
+		// side 1 cylinders 0..3 (tracks 0x80..0x83) are valid data sectors. The
+		// (0,0) chain terminator is already filtered out above.
+		if ref.Sector.Track < 4 {
 			findings = append(findings, Finding{
 				RuleID:   "DISK-DIRECTORY-TRACKS",
 				Severity: SeverityStructural,

--- a/rules_ft_basic.go
+++ b/rules_ft_basic.go
@@ -300,14 +300,30 @@ func checkBasicStartLineFFDisables(ctx *CheckContext) []Finding {
 }
 
 // ----- BASIC-STARTLINE-WITHIN-PROG -----
-// When auto-RUN is enabled, the start-line should correspond to an
-// actual line in the saved program. Cosmetic — auto-RUN of a missing
-// line just errors with "Statement lost", it's not a corruption.
+// When auto-RUN is enabled, the start-line should not exceed the
+// highest line number in the saved program. ROM BASIC's RUN N uses
+// NEXT-LINE-GE semantics (the lookup finds the first line whose
+// number is >= N), so `RUN N` where N is less than or equal to the
+// highest line in the program starts at the first line at or after
+// N — this is exactly the canonical "RUN 1 to start from the
+// beginning" idiom. Only `RUN N` where N is greater than every
+// saved line is a real bug: there's no line at or after N, and
+// BASIC errors out.
+//
+// Iteration 1 REWORD: previously fired on "start-line not present
+// in the saved program" — which mis-described the rule's intent
+// because the canonical "RUN 1 with first line 10" pattern (78% of
+// 3,074 corpus fires) is not an error, just a marker for "start
+// from the beginning". The catalog's "Statement lost" framing was
+// also wrong: SAM BASIC's NEXT-LINE-GE lookup means RUN N at or
+// below the lowest line is a no-op, not an error.
+//
+// Severity stays cosmetic.
 func init() {
 	Register(Rule{
 		ID:          "BASIC-STARTLINE-WITHIN-PROG",
 		Severity:    SeverityCosmetic,
-		Description: "FT_SAM_BASIC auto-RUN start-line exists in the saved program",
+		Description: "FT_SAM_BASIC auto-RUN start-line is at or below the highest saved line (RUN's NEXT-LINE-GE lookup tolerates start-lines below the lowest saved line)",
 		Citation:    "rom-disasm:22136-22141",
 		Check:       checkBasicStartLineWithinProg,
 	})
@@ -334,18 +350,29 @@ func checkBasicStartLineWithinProg(ctx *CheckContext) []Finding {
 		if err != nil {
 			return // BASIC-LINE-NUMBER-BE reports the parse failure
 		}
+		if len(bf.Lines) == 0 {
+			return // empty program; BASIC-LINE-NUMBER-BE / parse rules cover this
+		}
 		want := fe.SAMBASICStartLine
+		// Find the highest line number in the saved program.
+		var highest uint16
 		for _, ln := range bf.Lines {
-			if ln.Number == want {
-				return
+			if ln.Number > highest {
+				highest = ln.Number
 			}
 		}
-		findings = append(findings, Finding{
-			RuleID: "BASIC-STARTLINE-WITHIN-PROG", Severity: SeverityCosmetic,
-			Location: SlotLocation(slot, fe.Name.String()),
-			Message:  fmt.Sprintf("BASIC auto-RUN line %d not present in the saved program", want),
-			Citation: "rom-disasm:22136-22141",
-		})
+		// Iteration 1 REWORD: SAM BASIC RUN N uses NEXT-LINE-GE
+		// semantics. `want` at or below `highest` always resolves
+		// to a saved line (the first line whose number is >= want);
+		// only `want > highest` produces no line to run.
+		if want > highest {
+			findings = append(findings, Finding{
+				RuleID: "BASIC-STARTLINE-WITHIN-PROG", Severity: SeverityCosmetic,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("BASIC auto-RUN line %d is greater than the highest saved line %d; BASIC's NEXT-LINE-GE lookup will find no line to run", want, highest),
+				Citation: "rom-disasm:22136-22141",
+			})
+		}
 	})
 	return findings
 }

--- a/rules_ft_basic.go
+++ b/rules_ft_basic.go
@@ -185,12 +185,24 @@ func checkBasicProgEndSentinel(ctx *CheckContext) []Finding {
 // Walk the program with sambasic.Parse; any parse failure means the
 // big-endian line-number / little-endian length / 0x0D-terminator
 // invariant doesn't hold somewhere. Also check each line number is
-// in 1..16383.
+// non-zero (line 0 doesn't exist in SAM BASIC).
+//
+// Iteration 1 SCOPE: widened from 1..16383 to 1..65535. The 16383
+// cap came from a samfile-specific 0x3FFF mask, but SAM BASIC stores
+// line numbers as 16-bit big-endian — line numbers above 16383 are
+// legitimate. Corpus evidence: 1,098 fires / 385 disks, with several
+// hundred messages reading `line number 20000/50000/60000` — real
+// "library" / "internal" line numbers in published BASIC programs.
+// Line 0 (309 fires) remains structurally invalid: BASIC has no
+// line 0, so it is dropped from the accepted range.
+//
+// Line.Number is `uint16`, so the upper bound 65535 is implicit in
+// the type; only the `== 0` check remains as an explicit guard.
 func init() {
 	Register(Rule{
 		ID:          "BASIC-LINE-NUMBER-BE",
 		Severity:    SeverityStructural,
-		Description: "FT_SAM_BASIC program parses cleanly and every line number is in 1..16383",
+		Description: "FT_SAM_BASIC program parses cleanly and every line number is in 1..65535 (uint16 BE; widened from 1..16383 in iteration 1)",
 		Citation:    "sambasic/parse.go",
 		Check:       checkBasicLineNumberBE,
 	})
@@ -222,11 +234,13 @@ func checkBasicLineNumberBE(ctx *CheckContext) []Finding {
 			return
 		}
 		for _, ln := range bf.Lines {
-			if ln.Number < 1 || ln.Number > 16383 {
+			// Line 0 doesn't exist in SAM BASIC; the upper bound 65535
+			// is implicit in Line.Number's uint16 type.
+			if ln.Number == 0 {
 				findings = append(findings, Finding{
 					RuleID: "BASIC-LINE-NUMBER-BE", Severity: SeverityStructural,
 					Location: SlotLocation(slot, fe.Name.String()),
-					Message:  fmt.Sprintf("BASIC line number %d out of range (1..16383)", ln.Number),
+					Message:  fmt.Sprintf("BASIC line number %d out of range (1..65535)", ln.Number),
 					Citation: "sambasic/parse.go",
 				})
 				return // one finding per slot
@@ -268,11 +282,15 @@ func checkBasicStartLineFFDisables(ctx *CheckContext) []Finding {
 		}
 		if marker == 0x00 {
 			line := fe.SAMBASICStartLine
-			if line == 0 || line == 0xFFFF || line > 16383 {
+			// Iteration 1 SCOPE: line numbers are 16-bit BE; widen the
+			// accepted range from 1..16383 to 1..65534 (excluding 0xFFFF
+			// which is the no-auto-RUN sentinel). Companion to
+			// BASIC-LINE-NUMBER-BE.
+			if line == 0 || line == 0xFFFF {
 				findings = append(findings, Finding{
 					RuleID: "BASIC-STARTLINE-FF-DISABLES", Severity: SeverityStructural,
 					Location: SlotLocation(slot, fe.Name.String()),
-					Message:  fmt.Sprintf("BASIC auto-RUN enabled (dir[0xF2]=0x00) but start-line %d is invalid (1..16383)", line),
+					Message:  fmt.Sprintf("BASIC auto-RUN enabled (dir[0xF2]=0x00) but start-line %d is invalid (1..65534; 0xFFFF disables auto-RUN)", line),
 					Citation: "rom-disasm:22136-22141",
 				})
 			}

--- a/rules_ft_basic_test.go
+++ b/rules_ft_basic_test.go
@@ -187,6 +187,27 @@ func TestBasicLineNumberBENegative(t *testing.T) {
 	}
 }
 
+func TestBasicLineNumberBEAcceptsHighLineNumbers(t *testing.T) {
+	// Iteration 1 SCOPE regression: a line number above 16383 (the
+	// former samfile-specific cap) must not fire. Corpus disks use
+	// 20000/50000/60000 as legitimate "library" / "internal" line
+	// numbers.
+	bf := &sambasic.File{
+		StartLine: 60000,
+		Lines: []sambasic.Line{
+			{Number: 60000, Tokens: []sambasic.Token{sambasic.REM, sambasic.String("hi")}},
+		},
+	}
+	di := NewDiskImage()
+	if err := di.AddBasicFile("DEMO", bf); err != nil {
+		t.Fatalf("AddBasicFile (high line number): %v", err)
+	}
+	findings := checkBasicLineNumberBE(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("line 60000: %d findings; want 0 (line numbers up to 65535 are legitimate)", len(findings))
+	}
+}
+
 // ----- BASIC-STARTLINE-FF-DISABLES -----
 
 func TestBasicStartLineFFDisablesPositive(t *testing.T) {

--- a/rules_ft_basic_test.go
+++ b/rules_ft_basic_test.go
@@ -251,12 +251,31 @@ func TestBasicStartLineWithinProgNegative(t *testing.T) {
 	// SAMBASICStartLine and ExecutionAddressMod16K share the same on-disk
 	// bytes 0xF3-0xF4. Raw() serialises ExecutionAddressMod16K, so we must
 	// set both fields to make WriteFileEntry persist the change correctly.
-	dj[0].SAMBASICStartLine = 99  // line 99 not in program (only line 10 exists)
+	// Iteration 1 REWORD: rule now fires only when StartLine > highest
+	// saved line. Program has line 10, so line 99 > 10 fires (NEXT-LINE-GE
+	// lookup finds nothing).
+	dj[0].SAMBASICStartLine = 99
 	dj[0].ExecutionAddressMod16K = 99
 	di.WriteFileEntry(dj, 0)
 	findings := checkBasicStartLineWithinProg(&CheckContext{Disk: di, Journal: di.DiskJournal()})
 	if len(findings) != 1 || findings[0].RuleID != "BASIC-STARTLINE-WITHIN-PROG" {
 		t.Fatalf("got %d findings, first=%+v; want 1 BASIC-STARTLINE-WITHIN-PROG", len(findings), findings)
+	}
+}
+
+func TestBasicStartLineWithinProgAcceptsRun1Idiom(t *testing.T) {
+	// Iteration 1 REWORD regression test: the canonical "RUN 1 with
+	// first line N>1" pattern (78% of corpus fires) must not fire.
+	// SAM BASIC's NEXT-LINE-GE lookup means RUN 1 starts at the first
+	// line whose number is >= 1 — i.e. the lowest saved line. This
+	// is the standard "start from the beginning" idiom, not an error.
+	di, dj := buildBasicDisk(t) // program has line 10; auto-RUN=10 by default
+	dj[0].SAMBASICStartLine = 1 // RUN 1: NEXT-LINE-GE picks up line 10
+	dj[0].ExecutionAddressMod16K = 1
+	di.WriteFileEntry(dj, 0)
+	findings := checkBasicStartLineWithinProg(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("RUN 1 with first-line=10 (canonical idiom): %d findings; want 0", len(findings))
 	}
 }
 

--- a/rules_ft_code.go
+++ b/rules_ft_code.go
@@ -111,7 +111,7 @@ func checkCodeExecWithinLoadedRange(ctx *CheckContext) []Finding {
 }
 
 // ----- CODE-FILETYPEINFO-EMPTY -----
-// FileTypeInfo (dir 0xDD-0xE7) is unused for FT_CODE. Two conventions
+// FileTypeInfo (dir 0xDD-0xE7) is unused for FT_CODE. Three conventions
 // are observed in the wild:
 //
 //   - 0x00 × 11 — samfile's AddCodeFile leaves the struct zero-init.
@@ -119,16 +119,25 @@ func checkCodeExecWithinLoadedRange(ctx *CheckContext) []Finding {
 //     dir offset 0xDC via HDCLP2 (rom-disasm:22076-22080), which
 //     covers MGTFlags + the entire FileTypeInfo region + the first
 //     two bytes of ReservedA.
+//   - 0x20 — HDR space-fill leakage: ROM `HDCLP` at
+//     rom-disasm:22070-22074 fills 25 bytes of the HDR header buffer
+//     with 0x20 (space) during the names-area initialisation. When
+//     the dir entry is written, FileTypeInfo bytes 0xDD-0xE7 land in
+//     a region the HDR buffer overlaps, and the space-fill bleeds
+//     through for many writers. Empirical: 16,727 of 16,932 corpus
+//     fires (99%) are byte 0x20 — the dominance is striking enough
+//     that 0x20 is plainly a third canonical "unused" marker.
 //
-// Both are legitimate "unused" markers. The rule warns only when a
-// byte is in NEITHER convention — i.e. anything other than 0x00 or
-// 0xFF, which would suggest the slot was once a different file type
-// whose FileTypeInfo bytes weren't cleared on overwrite.
+// All three are legitimate "unused" markers. The rule warns only
+// when a byte is in NONE of these conventions — anything other than
+// 0x00, 0xFF, or 0x20 — which would suggest the slot was once a
+// different file type whose FileTypeInfo bytes weren't cleared on
+// overwrite.
 func init() {
 	Register(Rule{
 		ID:          "CODE-FILETYPEINFO-EMPTY",
 		Severity:    SeverityCosmetic,
-		Description: "FT_CODE file's FileTypeInfo (dir 0xDD-0xE7) is uniformly 0x00 (samfile) or 0xFF (ROM SAMDOS-2) — unused-marker convention",
+		Description: "FT_CODE file's FileTypeInfo (dir 0xDD-0xE7) is uniformly 0x00 (samfile), 0xFF (ROM SAMDOS-2), or 0x20 (HDR space-fill leakage) — unused-marker convention",
 		Citation:    "samfile.go:798-827",
 		Check:       checkCodeFileTypeInfoEmpty,
 	})
@@ -141,12 +150,15 @@ func checkCodeFileTypeInfoEmpty(ctx *CheckContext) []Finding {
 			return
 		}
 		for _, b := range fe.FileTypeInfo {
-			if b != 0x00 && b != 0xFF {
+			// Iteration 1 SCOPE: 0x20 is accepted as a third "unused"
+			// marker (ROM HDCLP names-area space-fill leakage, 99% of
+			// corpus fires).
+			if b != 0x00 && b != 0xFF && b != 0x20 {
 				findings = append(findings, Finding{
 					RuleID:   "CODE-FILETYPEINFO-EMPTY",
 					Severity: SeverityCosmetic,
 					Location: SlotLocation(slot, fe.Name.String()),
-					Message:  fmt.Sprintf("CODE file has 0x%02x in FileTypeInfo (dir 0xDD-0xE7) — neither samfile's 0x00 nor ROM SAVE's 0xFF unused-marker", b),
+					Message:  fmt.Sprintf("CODE file has 0x%02x in FileTypeInfo (dir 0xDD-0xE7) — none of samfile's 0x00, ROM SAVE's 0xFF, or HDR space-fill 0x20", b),
 					Citation: "samfile.go:798-827",
 				})
 				return // one finding per slot

--- a/rules_ft_code_test.go
+++ b/rules_ft_code_test.go
@@ -110,3 +110,19 @@ func TestCodeFileTypeInfoEmptyAcceptsAllFF(t *testing.T) {
 		t.Errorf("FileTypeInfo = 0xFF × 11 (ROM SAMDOS-2 convention): %d findings; want 0", len(findings))
 	}
 }
+
+func TestCodeFileTypeInfoEmptyAcceptsAll0x20(t *testing.T) {
+	// Iteration 1 SCOPE: 0x20 added as a third legitimate "unused"
+	// marker (HDR space-fill leakage from ROM HDCLP at
+	// rom-disasm:22070-22074). 99% of corpus FileTypeInfo-mismatch
+	// fires are byte 0x20 — the rule must not fire on this value.
+	di, dj := cleanSingleFileDisk(t, "TEST", 100)
+	for i := range dj[0].FileTypeInfo {
+		dj[0].FileTypeInfo[i] = 0x20
+	}
+	di.WriteFileEntry(dj, 0)
+	findings := checkCodeFileTypeInfoEmpty(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("FileTypeInfo = 0x20 × 11 (HDR space-fill leakage): %d findings; want 0", len(findings))
+	}
+}

--- a/rules_ft_screen.go
+++ b/rules_ft_screen.go
@@ -40,15 +40,27 @@ func checkScreenModeAt0xDD(ctx *CheckContext) []Finding {
 }
 
 // ----- SCREEN-LENGTH-MATCHES-MODE -----
-// For FT_SCREEN, body Length() matches the documented screen size for
-// the given mode: modes 1 and 2 → 6912 bytes, modes 3 and 4 → 24576
-// bytes. (Skipped when mode is out-of-range; SCREEN-MODE-AT-0xDD
-// catches that.)
+// For FT_SCREEN, body Length() must be at least the documented
+// screen-data size for the given mode: modes 1 and 2 → 6912 bytes,
+// modes 3 and 4 → 24576 bytes. ROM SCREEN$ SAVE typically appends a
+// palette + sysvars trailer (16 bytes of CLUT + LINE/ATTR/state) so
+// real-world MODE 3/4 screens are commonly 24576+41 = 24617 bytes;
+// LOAD SCREEN$ ignores the trailer. (Skipped when mode is
+// out-of-range; SCREEN-MODE-AT-0xDD catches that.)
+//
+// Iteration 1 REWORD: previously required strict equality with the
+// canonical size, which fired on the 75% of corpus MODE 3/4
+// screens that include the standard ROM-SAVE palette trailer.
+// New rule: fire when Length < min (genuinely-truncated) or
+// Length > min + 512 (suspiciously-long). The 512-byte slack
+// accommodates the documented trailer plus reasonable wiggle room
+// while still catching the rare mode-mismatch case (e.g. mode 2
+// dir byte but mode-3-sized body).
 func init() {
 	Register(Rule{
 		ID:          "SCREEN-LENGTH-MATCHES-MODE",
 		Severity:    SeverityStructural,
-		Description: "FT_SCREEN body length matches the documented size for its mode (1-2: 6912; 3-4: 24576)",
+		Description: "FT_SCREEN body length is within [min, min+512] for its mode (1-2: min=6912; 3-4: min=24576) — slack accommodates the ROM SCREEN$ SAVE palette+sysvars trailer",
 		Citation:    "sam-coupe_tech-man_v3-0.txt",
 		Check:       checkScreenLengthMatchesMode,
 	})
@@ -61,20 +73,30 @@ func checkScreenLengthMatchesMode(ctx *CheckContext) []Finding {
 			return
 		}
 		mode := fe.FileTypeInfo[0]
-		var expected uint32
+		var minSize uint32
 		switch mode {
 		case 1, 2:
-			expected = 6912
+			minSize = 6912
 		case 3, 4:
-			expected = 24576
+			minSize = 24576
 		default:
 			return // SCREEN-MODE-AT-0xDD reports the bad mode
 		}
-		if fe.Length() != expected {
+		const trailerSlack = 512 // palette + sysvars + headroom
+		length := fe.Length()
+		switch {
+		case length < minSize:
 			findings = append(findings, Finding{
 				RuleID: "SCREEN-LENGTH-MATCHES-MODE", Severity: SeverityStructural,
 				Location: SlotLocation(slot, fe.Name.String()),
-				Message:  fmt.Sprintf("SCREEN mode %d expects body length %d; got %d", mode, expected, fe.Length()),
+				Message:  fmt.Sprintf("SCREEN mode %d body length %d is shorter than mode minimum %d bytes", mode, length, minSize),
+				Citation: "sam-coupe_tech-man_v3-0.txt",
+			})
+		case length > minSize+trailerSlack:
+			findings = append(findings, Finding{
+				RuleID: "SCREEN-LENGTH-MATCHES-MODE", Severity: SeverityStructural,
+				Location: SlotLocation(slot, fe.Name.String()),
+				Message:  fmt.Sprintf("SCREEN mode %d body length %d exceeds mode maximum %d bytes (min %d + %d trailer slack)", mode, length, minSize+trailerSlack, minSize, trailerSlack),
 				Citation: "sam-coupe_tech-man_v3-0.txt",
 			})
 		}

--- a/rules_ft_screen_test.go
+++ b/rules_ft_screen_test.go
@@ -53,3 +53,22 @@ func TestScreenLengthMatchesModeNegative(t *testing.T) {
 		t.Fatalf("got %d findings, first=%+v; want 1 SCREEN-LENGTH-MATCHES-MODE", len(findings), findings)
 	}
 }
+
+func TestScreenLengthMatchesModeAcceptsPaletteTrailer(t *testing.T) {
+	// Iteration 1 REWORD regression: mode 3 + 24617 bytes (24576
+	// screen data + 41-byte palette/sysvars trailer) is the canonical
+	// ROM SCREEN$ SAVE output and must not fire. 75% of corpus
+	// SCREEN-LENGTH fires were this exact length.
+	di := NewDiskImage()
+	if err := di.AddCodeFile("SCRTR", make([]byte, 24617), 0x8000, 0); err != nil {
+		t.Fatalf("AddCodeFile: %v", err)
+	}
+	dj := di.DiskJournal()
+	dj[0].Type = FT_SCREEN
+	dj[0].FileTypeInfo[0] = 3
+	di.WriteFileEntry(dj, 0)
+	findings := checkScreenLengthMatchesMode(&CheckContext{Disk: di, Journal: di.DiskJournal()})
+	if len(findings) != 0 {
+		t.Errorf("mode 3 + 24617 bytes (canonical palette trailer): %d findings; want 0", len(findings))
+	}
+}


### PR DESCRIPTION
**Phase 7 (corpus-validation) first pass.** Three iterations of propose / review / implement / re-measure against an 800-disk corpus assembled from `~/Downloads/GoodSamC2/` + scattered local sources. The full audit trail is at `docs/notes/corpus-reclassification-2026-05-12.md` (this PR adds it).

## TL;DR

| Metric | iter-0 | iter-3 | Δ |
|---|---:|---:|---:|
| Total findings | 299,639 | 227,572 | −24% |
| Fatal | 165,620 | 1,937 | **−98.8%** |
| Structural | 65,254 | 11,532 | −82% |
| Inconsistency | 42,798 | 172,949 | (redistribution from above) |
| Cosmetic | 25,967 | 41,154 | (redistribution from above) |
| Disks with zero findings | 1 | 6 | +5 |
| Disks with no fatal | 204 (25.5%) | 621 (77.6%) | +52pp |
| Disks clean at default threshold | 1 (0.1%) | 149 (18.6%) | +18pp |

**The M0 regression gate held every iteration** — `~/sam-corpus/disks/test.mgt` (samdos2 boot disk) stays at zero findings throughout.

## Three iterations, 17 commits

**Iter 1 (11 commits)** — fixed a triple-rule cylinder-mask bug + demoted/scoped the obvious noise:

- `f619d9a` **FIX** `DIR-FIRST-SECTOR-VALID` / `DISK-DIRECTORY-TRACKS` / `CROSS-DIRECTORY-AREA-UNUSED` — single root cause: the `(track & 0x7F) < 4` mask incorrectly rejected side-1 tracks 128-131 (cylinders 0-3 on side 1, which are *valid* data sectors; the directory area is only on side 0). Accounted for ~40,600 of the corpus's 42,000 false positives across the three rules (97%).
- `bff412c` **DEMOTE** `CROSS-NO-SECTOR-OVERLAP` fatal → structural — SAMDOS chain walk doesn't consult the SectorAddressMap (`samdos/src/b.s:33-126`).
- `6d14929` **DEMOTE** `BOOT-OWNER-AT-T4S1` fatal → structural — archive disks legitimately aren't bootable.
- `ac9d120` **DEMOTE** `BOOT-SIGNATURE-AT-256` fatal → structural — missing BOOT signature = non-bootability, not corruption.
- `365fa7e` / `ffb30da` **SCOPE** `BODY-EXEC-DIV16K-MATCHES-DIR` / `BODY-EXEC-MOD16K-LO-MATCHES-DIR` — skip when body[5]==0xFF (canonical "defer to dir" pattern; see also issue #21).
- `07d3dc1` **SCOPE** `CODE-FILETYPEINFO-EMPTY` — accept 0x20 as third "unused" marker (HDR space-fill leakage).
- `9a1ae0b` **SCOPE** `BASIC-LINE-NUMBER-BE` / `BASIC-STARTLINE-FF-DISABLES` — widen line range to 1..65535 (uint16).
- `67491f4` **REWORD** `BASIC-STARTLINE-WITHIN-PROG` — fire only when auto-RUN line exceeds highest saved line (catches the genuine "Statement lost" case, ignores the canonical `RUN 1` idiom with first line >= 1).
- `277aa42` **REWORD** `SCREEN-LENGTH-MATCHES-MODE` — accept ROM SCREEN\$'s palette+sysvars trailer.
- `27216be` **FIX** `DIR-TYPE-BYTE-IS-KNOWN` — skip Type==0 (eliminates 100% double-fire with `DIR-ERASED-IS-ZERO`).

**Iter 2 (2 commits)** — the body-mirror cluster:

- `2b8aa1a` **DEMOTE** 6 body-mirror rules (`BODY-MIRROR-AT-DIR-D3-DB` + `BODY-{TYPE,LENGTHMOD16K,PAGEOFFSET,PAGES,STARTPAGE}-MATCHES-DIR`) inconsistency → cosmetic. Body bytes 0..8 are **unused** on LOAD: SAMDOS's `ldhd` (`samdos/src/f.s:494-497`) discards the body header bytes via `lbyt` (`samdos/src/c.s:557-570`), `dschd` (h.s:74-90) populates HDL from caller-provided registers, and `hconr` (h.s:336-361) reads the cache from the dir entry via `gtfle`. So body-vs-dir divergence has zero LOAD-time consequence — it's a SAVE-time writer convention.
- `6d282a7` **DEMOTE** + **REWORD** `DIR-ERASED-IS-ZERO` structural → inconsistency — DEL/ERASE residual is normal archaeology, not corruption.

**Iter 3 (3 commits)** — the deferred trio + DIR-SECTORS-MATCHES-CHAIN:

- `86c08d1` **DEMOTE** `CROSS-NO-SECTOR-OVERLAP` structural → inconsistency — SAMDOS LOAD doesn't read the merged SAM map; allocator-only hazard.
- `3287b03` **DEMOTE** `CHAIN-MATCHES-SAM` structural → inconsistency — chain is the LOAD authority, SAM map is SAVE-side bookkeeping.
- `f7a1d42` **REWORD** `DIR-SECTORS-MATCHES-CHAIN` — surface the `samfile.File()` consumer hazard. **Severity stays structural** because samfile reads exactly `fe.Sectors` chunks ignoring the (0,0) terminator (`samfile.go:743-754`), so a mismatch causes garbage reads — that's the spec's "violation produces undefined behaviour" definition.

Plus `1a4c7da` — final report in `docs/notes/`.

## Where the reviewer overruled the proposer

Three substantive cases where independent review caught proposer errors:

1. **iter-1**: proposer mislabeled which BODY-EXEC firing pattern was most common (text-only fix, code change was sound).
2. **iter-2**: proposer's "body wins on LOAD" framing was *inverted* — verified samdos source shows body[0..8] are *unused* on LOAD; the dir mirror feeds ROM. Same conclusion (demote to cosmetic) but for the opposite reason. **This also surfaces a catalog §0 PR-12-hypotheses text inversion** that's flagged for follow-up.
3. **iter-3**: proposer demoted `DIR-SECTORS-MATCHES-CHAIN` to inconsistency on a SAMDOS-only reading of "structural"; reviewer pointed out the spec defines structural more broadly (covers samfile-consumer hazards too). Only the reword landed.

## What we deliberately KEPT

5 high-fire rules where the corpus signal is real (likely genuine corruption / non-canonical disks):

- `DIR-FIRST-SECTOR-VALID` — bug fixed in iter-1; residual 19.6% are real
- `DISK-SECTOR-RANGE` — fires only on genuinely malformed bytes
- `BASIC-VARS-GAP-INVARIANT` — dialect-aware; residuals are real
- `BASIC-LINE-NUMBER-BE` + `BASIC-STARTLINE-FF-DISABLES` — iter-1 widened ranges; residuals are real

## Deferred follow-ups

1. **CROSS-NO-SECTOR-OVERLAP per-disk summary mode** — currently fires 162k times per corpus run (one per overlapping sector); a future summary-mode feature would emit one finding per disk with a count instead.
2. **Catalog §0 hconr narrative correction** — iter-2 reviewer flagged that the §0 PR-12-verification text describes the SAMDOS LOAD path inversely from reality. Needs a careful catalog edit citing the verified `gtfle→uifa→hconr→txhed` chain.
3. **BODY-EXEC body[5..6] BASIC-mirror investigation** (existing samfile#21).
4. **`samfile.go:390` debug.PrintStack noise** (existing samfile#19).

## Test plan

- [x] `go test ./...` — all green at every iteration (51 rules registered throughout — registry count unchanged)
- [x] `go vet ./...` — clean
- [x] M0 boot disk regression gate held every iteration (`detected dialect: samdos2`, `no findings`)
- [x] Corpus re-measured after every commit batch
- [ ] GitHub Actions CI green

## Reading order for review

1. **Final report** at `docs/notes/corpus-reclassification-2026-05-12.md` — the audit trail
2. Per-commit diffs in chronological order (oldest first)
3. The 4 deferred follow-up issues (linked above) — confirm scope is right

🤖 Generated with [Claude Code](https://claude.com/claude-code)