### PR TITLE
feat(verify): per-subject audit framework + first corpus-grounded rule fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 # samfile package name; anchor with leading / so we don't ignore
 # any future samfile/ source subdirectory.
 /samfile
+tools/audit/__pycache__/

--- a/check_event.go
+++ b/check_event.go
@@ -1,0 +1,35 @@
+package samfile
+
+// CheckEvent is the per-subject record emitted by Verify when a rule
+// declares Scope + CheckSubject. One event per (rule, applicable
+// subject) pair. Legacy rules (Check-only) emit one event per finding
+// they produce, with Outcome=fail and a synthetic Subject ref.
+type CheckEvent struct {
+	Version int            `json:"v"`
+	Disk    string         `json:"disk"`
+	RuleID  string         `json:"rule_id"`
+	Scope   string         `json:"scope"`
+	Ref     string         `json:"ref"`
+	Outcome string         `json:"outcome"` // pass | fail | not_applicable
+	Attrs   map[string]any `json:"attrs,omitempty"`
+	Finding *Finding       `json:"finding,omitempty"`
+}
+
+// EventRecorder collects CheckEvents during a Verify run. The verify
+// CLI installs a recorder when --format jsonl is set; for normal text
+// output the recorder is nil and no events are kept.
+type EventRecorder struct {
+	Events []CheckEvent
+	Disk   string
+}
+
+func (r *EventRecorder) Record(e CheckEvent) {
+	if r == nil {
+		return
+	}
+	e.Version = 1
+	if e.Disk == "" {
+		e.Disk = r.Disk
+	}
+	r.Events = append(r.Events, e)
+}

--- a/cmd/samfile/main.go
+++ b/cmd/samfile/main.go
@@ -44,7 +44,11 @@ func main() {
 	case arguments["add"]:
 		add(arguments)
 	case arguments["verify"]:
-		if err := runVerify(arguments["-i"].(string)); err != nil {
+		format := "text"
+		if v, ok := arguments["--format"].(string); ok && v != "" {
+			format = v
+		}
+		if err := runVerify(arguments["-i"].(string), format); err != nil {
 			log.Fatal(err)
 		}
 	default:

--- a/cmd/samfile/usage.go
+++ b/cmd/samfile/usage.go
@@ -11,7 +11,7 @@ Manipulate files in SAM Coupé floppy disk images.
     samfile cat -i IMAGE -f FILE
     samfile extract -i IMAGE [-t TARGET]
     samfile ls -i IMAGE
-    samfile verify -i IMAGE
+    samfile verify -i IMAGE [--format FORMAT]
     samfile --help
     samfile --version
 
@@ -41,6 +41,9 @@ Manipulate files in SAM Coupé floppy disk images.
     -c                    File is a code file.
     -l LOAD_ADDRESS       Load address of code file on the SAM Disk image.
     -e EXECUTION_ADDRESS  Execution address of code file on the SAM Disk image.
+    --format FORMAT       Output format for verify: "text" (default,
+                          human readable) or "jsonl" (one JSON Check
+                          event per line; for audit pipelines).
     --help                Display this help text.
     --version             Display the release version of samfile.
 

--- a/cmd/samfile/verify.go
+++ b/cmd/samfile/verify.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/petemoore/samfile/v3"
@@ -23,10 +26,23 @@ import (
 // (image-path in, error out); Task 10 wires it into the dispatcher
 // by extracting arguments["-i"].(string) and calling log.Fatal on
 // a non-nil return.
-func runVerify(imagePath string) error {
+func runVerify(imagePath string, format string) error {
 	di, err := samfile.Load(imagePath)
 	if err != nil {
 		return fmt.Errorf("verify: %w", err)
+	}
+
+	if format == "jsonl" {
+		base := strings.TrimSuffix(filepath.Base(imagePath), filepath.Ext(imagePath))
+		rec := &samfile.EventRecorder{Disk: base}
+		_ = di.VerifyWithRecorder(rec)
+		enc := json.NewEncoder(os.Stdout)
+		for _, ev := range rec.Events {
+			if err := enc.Encode(ev); err != nil {
+				return fmt.Errorf("verify: %w", err)
+			}
+		}
+		return nil
 	}
 
 	report := di.Verify()

--- a/cmd/samfile/verify_test.go
+++ b/cmd/samfile/verify_test.go
@@ -171,7 +171,7 @@ func captureVerify(t *testing.T, imgPath string) (string, error) {
 	os.Stdout = w
 	defer func() { os.Stdout = old }()
 
-	err := runVerify(imgPath)
+	err := runVerify(imgPath, "text")
 
 	w.Close()
 	var buf bytes.Buffer

--- a/docs/plans/2026-05-12-verify-audit-framework.md
+++ b/docs/plans/2026-05-12-verify-audit-framework.md
@@ -1,0 +1,1262 @@
+# Verify Audit Framework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Instrument the verify pipeline so every rule emits a Check event (pass / fail / not_applicable) per subject with attribute snapshots; ingest those into a SQLite `checks` table and emit five Markdown reports under `~/sam-corpus/analyses/`, prioritising fallback-floor reports (`coverage.md`, `disk-health.md`) that need only plain pandas counts; then loop on high-confidence patterns with source-citation grounding to land rule fixes on `feat/verify-audit-framework`.
+
+**Architecture:** Add `Scope` + `Applies` + `CheckSubject` to the Go `Rule` struct. Framework enumerates per-scope subjects (Disk / Slot / ChainStep), evaluates Applies (denominator) and CheckSubject (numerator + finding payload), emits `CheckEvent`s. A new `--format jsonl` flag on `samfile verify` writes one JSON event per line. Python `tools/audit/{ingest,mine}.py` slurps JSONL into `findings.db` and produces reports.
+
+**Tech Stack:** Go 1.21+ (samfile repo). Python 3.11+ with pandas, sklearn (`DecisionTreeClassifier`), mlxtend (`apriori`, `association_rules`). SQLite 3 (`findings.db`).
+
+**Reference paths:**
+- samfile repo: `~/git/samfile/`
+- corpus workspace: `~/sam-corpus/`
+- SAMDOS source: `~/git/samdos/src/*.s`
+- ROM disasm: `~/git/sam-aarch64/docs/sam/sam-coupe_rom-v3.0_annotated-disassembly.txt`
+- Design spec: `docs/specs/2026-05-12-verify-audit-framework-design.md`
+
+---
+
+## Phase 1 — Foundation (Go)
+
+### Task 1: Subject interface + scope types
+
+**Files:**
+- Create: `subject.go`
+
+- [ ] **Step 1:** Create `subject.go` with:
+
+```go
+package samfile
+
+// SubjectScope identifies the kind of subject a Rule operates on.
+type SubjectScope int
+
+const (
+	DiskScope SubjectScope = iota
+	SlotScope
+	ChainStepScope
+)
+
+func (s SubjectScope) String() string {
+	switch s {
+	case DiskScope:
+		return "disk"
+	case SlotScope:
+		return "slot"
+	case ChainStepScope:
+		return "chain_step"
+	}
+	return "unknown"
+}
+
+// Subject is the universal interface for anything a rule can check —
+// a whole disk, a directory slot, or a single sector in a file's
+// chain. Ref() returns a stable string id; Attributes() returns the
+// denormalised attribute snapshot recorded with every Check event.
+type Subject interface {
+	Ref() string
+	Attributes() map[string]any
+}
+```
+
+- [ ] **Step 2:** Commit.
+
+```bash
+git add subject.go
+git commit -m "feat(verify): add Subject interface + SubjectScope enum"
+```
+
+---
+
+### Task 2: DiskSubject
+
+**Files:**
+- Create: `subject_disk.go`
+
+- [ ] **Step 1:** Create `subject_disk.go`:
+
+```go
+package samfile
+
+// DiskSubject wraps a DiskJournal + DiskImage for disk-scope rule
+// evaluation. Single instance per Verify() run.
+type DiskSubject struct {
+	Journal *DiskJournal
+	Disk    *DiskImage
+	Dialect Dialect
+}
+
+func (s *DiskSubject) Ref() string { return "disk" }
+
+func (s *DiskSubject) Attributes() map[string]any {
+	j := s.Journal
+	used := 0
+	for _, fe := range j.UsedSlots() {
+		_ = fe
+		used++
+	}
+	bootSig := false
+	if sd, err := s.Disk.SectorData(&Sector{Track: 4, Sector: 1}); err == nil {
+		if string(sd[256:259]) == "BOOT" {
+			bootSig = true
+		}
+	}
+	return map[string]any{
+		"dialect":                s.Dialect.String(),
+		"boot_signature_present": bootSig,
+		"used_slot_count":        used,
+	}
+}
+```
+
+- [ ] **Step 2:** Verify it compiles.
+
+```bash
+go build ./...
+```
+
+Expected: no errors.
+
+- [ ] **Step 3:** Commit.
+
+```bash
+git add subject_disk.go
+git commit -m "feat(verify): add DiskSubject with dialect/boot/used-slot attrs"
+```
+
+---
+
+### Task 3: SlotSubject
+
+**Files:**
+- Create: `subject_slot.go`
+
+- [ ] **Step 1:** Create `subject_slot.go`:
+
+```go
+package samfile
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+// SlotSubject wraps one directory slot's FileEntry for slot-scope
+// rule evaluation. SlotIndex is the 0..79 position; FileEntry is
+// the parsed dir entry. For erased slots (Type==0) the FileEntry
+// still exists but most fields are zero.
+type SlotSubject struct {
+	SlotIndex int
+	FileEntry *FileEntry
+	Disk      *DiskImage
+	Journal   *DiskJournal
+}
+
+func (s *SlotSubject) Ref() string { return fmt.Sprintf("slot=%d", s.SlotIndex) }
+
+func (s *SlotSubject) Attributes() map[string]any {
+	fe := s.FileEntry
+	pageOffsetForm := "other"
+	switch fe.StartAddressPageOffset & 0xC000 {
+	case 0x8000:
+		pageOffsetForm = "0x8000"
+	case 0x4000:
+		pageOffsetForm = "0x4000"
+	case 0x0000:
+		pageOffsetForm = "0x0000"
+	case 0xC000:
+		pageOffsetForm = "0xC000"
+	}
+	dirMirror := s.Disk[directoryByteOffset(s.SlotIndex)+0xD3 : directoryByteOffset(s.SlotIndex)+0xDC]
+	dirMirrorPopulated := false
+	for _, b := range dirMirror {
+		if b != 0 {
+			dirMirrorPopulated = true
+			break
+		}
+	}
+	hasAutoRun := fe.ExecutionAddressDiv16K != 0xFF
+	return map[string]any{
+		"slot_index":              s.SlotIndex,
+		"filename":                fe.Name.String(),
+		"file_type":               fe.Type.String(),
+		"file_type_byte":          int(fe.Type),
+		"file_length":             int(fe.LengthMod16K),
+		"page_offset_form":        pageOffsetForm,
+		"pages":                   int(fe.Pages),
+		"mgt_flags":               int(fe.MGTFlags),
+		"first_track":             int(fe.FirstSector.Track),
+		"first_sector":            int(fe.FirstSector.Sector),
+		"first_side":              int(fe.FirstSector.Track >> 7),
+		"has_autorun_or_autoexec": hasAutoRun,
+		"dir_mirror_populated":    dirMirrorPopulated,
+		"slot_is_erased":          fe.Type == 0,
+		"file_type_info_hex":      hex.EncodeToString(fe.FileTypeInfo[:]),
+		"sectors_count":           int(fe.Sectors),
+	}
+}
+
+// directoryByteOffset returns the byte offset of dir slot N (0..79)
+// within the MGT disk image, accounting for the cylinder-interleaved
+// layout. Tracks 0..3 of side 0 hold the directory; each track has
+// 20 slots; each slot is 256 bytes.
+func directoryByteOffset(slot int) int {
+	track := slot / 20
+	slotInTrack := slot % 20
+	return track*10240 + slotInTrack*256
+}
+```
+
+- [ ] **Step 2:** Verify it compiles.
+
+```bash
+go build ./...
+```
+
+- [ ] **Step 3:** Commit.
+
+```bash
+git add subject_slot.go
+git commit -m "feat(verify): add SlotSubject with slot-attribute snapshot"
+```
+
+---
+
+### Task 4: ChainStepSubject
+
+**Files:**
+- Create: `subject_chain.go`
+
+- [ ] **Step 1:** Create `subject_chain.go`:
+
+```go
+package samfile
+
+import "fmt"
+
+// ChainStepSubject wraps one step in a file's sector chain. Track
+// and Sector identify the sector itself; ChainIndex is the 0..N-1
+// position within this slot's chain.
+type ChainStepSubject struct {
+	SlotIndex   int
+	ChainIndex  int
+	Track       uint8
+	Sector      uint8
+	NextTrack   uint8
+	NextSector  uint8
+	Position    string // first | intermediate | last | orphan
+	OnSAMMap    bool
+	OnDirSAMMap bool
+	Disk        *DiskImage
+	Journal     *DiskJournal
+}
+
+func (s *ChainStepSubject) Ref() string {
+	return fmt.Sprintf("slot=%d,chain=%d,track=%d,sector=%d", s.SlotIndex, s.ChainIndex, s.Track, s.Sector)
+}
+
+func (s *ChainStepSubject) Attributes() map[string]any {
+	side := 0
+	if s.Track&0x80 != 0 {
+		side = 1
+	}
+	// Distance from dir tracks: dir is tracks 0..3 of side 0.
+	dirDistance := 999
+	t := int(s.Track & 0x7F)
+	if side == 0 {
+		if t >= 4 {
+			dirDistance = t - 3
+		} else {
+			dirDistance = 0
+		}
+	} else {
+		dirDistance = t + 1
+	}
+	return map[string]any{
+		"slot_index":               s.SlotIndex,
+		"chain_index":              s.ChainIndex,
+		"chain_position":           s.Position,
+		"track":                    int(s.Track),
+		"sector":                   int(s.Sector),
+		"side":                     side,
+		"next_track":               int(s.NextTrack),
+		"next_sector":              int(s.NextSector),
+		"on_sam_map":               s.OnSAMMap,
+		"on_dir_sam_map":           s.OnDirSAMMap,
+		"distance_from_dir_tracks": dirDistance,
+	}
+}
+```
+
+- [ ] **Step 2:** Verify it compiles.
+
+```bash
+go build ./...
+```
+
+- [ ] **Step 3:** Commit.
+
+```bash
+git add subject_chain.go
+git commit -m "feat(verify): add ChainStepSubject with chain-step attributes"
+```
+
+---
+
+### Task 5: Extend `Rule` struct with Scope + Applies + CheckSubject
+
+**Files:**
+- Modify: `verify.go:119-126` (Rule struct)
+
+- [ ] **Step 1:** Replace the `Rule` struct with:
+
+```go
+type Rule struct {
+	ID          string // catalog-stable, e.g. "DISK-NOT-EMPTY"
+	Severity    Severity
+	Dialects    []Dialect // dialects the rule applies to; nil/empty = all
+	Description string    // one-line summary, used in human output
+	Citation    string    // file:line of the strongest evidence
+
+	// Legacy single-shot check. Mutually exclusive with Scope + CheckSubject.
+	// Kept for rules that haven't been migrated to the per-subject model.
+	Check func(ctx *CheckContext) []Finding
+
+	// Per-subject scope. If unset (zero value = DiskScope) AND CheckSubject
+	// is nil, the rule is treated as legacy (Check is called once per Verify).
+	Scope SubjectScope
+
+	// Applies reports whether subject is eligible for this rule. If nil,
+	// the rule applies to all subjects of its Scope. Counted as the
+	// denominator for fail-rate analysis.
+	Applies func(ctx *CheckContext, subject Subject) bool
+
+	// CheckSubject evaluates one applicable subject. Returns nil for
+	// pass, a Finding pointer for fail. The framework calls this once
+	// per applicable subject and emits a CheckEvent for each call.
+	CheckSubject func(ctx *CheckContext, subject Subject) *Finding
+}
+```
+
+- [ ] **Step 2:** Verify it compiles.
+
+```bash
+go build ./...
+```
+
+Expected: compiles. Existing rules still register fine because all new fields are optional.
+
+- [ ] **Step 3:** Commit.
+
+```bash
+git add verify.go
+git commit -m "feat(verify): extend Rule struct with Scope/Applies/CheckSubject (back-compat)"
+```
+
+---
+
+### Task 6: Framework iteration + CheckEvent emission
+
+**Files:**
+- Create: `check_event.go`
+- Modify: `verify.go` (rewrite `(*DiskImage).Verify()`, add iteration helpers)
+
+- [ ] **Step 1:** Create `check_event.go`:
+
+```go
+package samfile
+
+// CheckEvent is the per-subject record emitted by Verify when a rule
+// declares Scope + CheckSubject. One event per (rule, applicable
+// subject) pair. Legacy rules (Check-only) emit one event per finding
+// they produce, with Outcome=fail and a synthetic Subject ref.
+type CheckEvent struct {
+	Version int            `json:"v"`
+	Disk    string         `json:"disk"`
+	RuleID  string         `json:"rule_id"`
+	Scope   string         `json:"scope"`
+	Ref     string         `json:"ref"`
+	Outcome string         `json:"outcome"` // pass | fail | not_applicable
+	Attrs   map[string]any `json:"attrs"`
+	Finding *Finding       `json:"finding,omitempty"`
+}
+
+// EventRecorder collects CheckEvents during a Verify run. The verify
+// CLI installs a recorder when --format jsonl is set; for normal text
+// output the recorder is nil and no events are kept.
+type EventRecorder struct {
+	Events []CheckEvent
+	Disk   string
+}
+
+func (r *EventRecorder) Record(e CheckEvent) {
+	if r == nil {
+		return
+	}
+	e.Version = 1
+	e.Disk = r.Disk
+	r.Events = append(r.Events, e)
+}
+```
+
+- [ ] **Step 2:** Modify `verify.go` `CheckContext` to add recorder + subject iterators. Append after the existing `CheckContext` struct (around line 164):
+
+```go
+// Recorder, if non-nil, receives a CheckEvent per (rule, applicable
+// subject) when a Rule declares Scope + CheckSubject. The text-output
+// path leaves this nil.
+func (ctx *CheckContext) SetRecorder(r *EventRecorder) { ctx.recorder = r }
+
+func (ctx *CheckContext) recorderRef() *EventRecorder { return ctx.recorder }
+```
+
+And add a field to the struct itself:
+
+```go
+type CheckContext struct {
+	Disk     *DiskImage
+	Journal  *DiskJournal
+	Dialect  Dialect
+	recorder *EventRecorder
+}
+```
+
+- [ ] **Step 3:** Add `subjectsForScope`:
+
+```go
+// subjectsForScope enumerates every Subject of the given scope on
+// the current disk. DiskScope yields one DiskSubject; SlotScope
+// yields 80 SlotSubjects (every dir entry, used or erased);
+// ChainStepScope yields one ChainStepSubject per sector in every
+// used file's chain.
+func (ctx *CheckContext) subjectsForScope(scope SubjectScope) []Subject {
+	switch scope {
+	case DiskScope:
+		return []Subject{&DiskSubject{Journal: ctx.Journal, Disk: ctx.Disk, Dialect: ctx.Dialect}}
+	case SlotScope:
+		out := make([]Subject, 0, 80)
+		for i := 0; i < 80; i++ {
+			fe := ctx.Journal.SlotAt(i)
+			out = append(out, &SlotSubject{SlotIndex: i, FileEntry: fe, Disk: ctx.Disk, Journal: ctx.Journal})
+		}
+		return out
+	case ChainStepScope:
+		var out []Subject
+		for i := 0; i < 80; i++ {
+			fe := ctx.Journal.SlotAt(i)
+			if fe.Type == 0 {
+				continue
+			}
+			chain := ctx.Journal.ChainForSlot(i)
+			for idx, step := range chain {
+				pos := "intermediate"
+				if idx == 0 {
+					pos = "first"
+				}
+				if idx == len(chain)-1 {
+					if pos == "first" {
+						pos = "first" // single-sector files
+					} else {
+						pos = "last"
+					}
+				}
+				out = append(out, &ChainStepSubject{
+					SlotIndex:  i,
+					ChainIndex: idx,
+					Track:      step.Track,
+					Sector:     step.Sector,
+					NextTrack:  step.NextTrack,
+					NextSector: step.NextSector,
+					Position:   pos,
+					Disk:       ctx.Disk,
+					Journal:    ctx.Journal,
+				})
+			}
+		}
+		return out
+	}
+	return nil
+}
+```
+
+This task assumes `DiskJournal` has `SlotAt(int) *FileEntry` and `ChainForSlot(int) []ChainStep` helpers. **If they don't exist, defer this task and implement them first.** Verify:
+
+```bash
+grep -nE "func.*DiskJournal.*SlotAt|func.*DiskJournal.*ChainForSlot|func.*DiskJournal.*UsedSlots" *.go
+```
+
+If missing, this task expands to also create those helpers (read the existing journal struct to see what's already there).
+
+- [ ] **Step 4:** Rewrite `Verify()`:
+
+```go
+func (di *DiskImage) Verify() VerifyReport {
+	return di.verifyInternal(nil)
+}
+
+// VerifyWithRecorder runs verify and captures every Check event into
+// the provided recorder (in addition to the existing VerifyReport).
+// Use this from the JSONL CLI path.
+func (di *DiskImage) VerifyWithRecorder(rec *EventRecorder) VerifyReport {
+	return di.verifyInternal(rec)
+}
+
+func (di *DiskImage) verifyInternal(rec *EventRecorder) VerifyReport {
+	dialect := DetectDialect(di)
+	ctx := &CheckContext{
+		Disk:     di,
+		Journal:  di.DiskJournal(),
+		Dialect:  dialect,
+		recorder: rec,
+	}
+	report := VerifyReport{Dialect: dialect}
+	for _, rule := range allRules {
+		if !ruleAppliesToDialect(rule, dialect) {
+			continue
+		}
+		if rule.CheckSubject != nil {
+			subjects := ctx.subjectsForScope(rule.Scope)
+			for _, subj := range subjects {
+				applicable := rule.Applies == nil || rule.Applies(ctx, subj)
+				if !applicable {
+					rec.Record(CheckEvent{RuleID: rule.ID, Scope: rule.Scope.String(), Ref: subj.Ref(), Outcome: "not_applicable", Attrs: subj.Attributes()})
+					continue
+				}
+				finding := rule.CheckSubject(ctx, subj)
+				outcome := "pass"
+				if finding != nil {
+					outcome = "fail"
+					report.Findings = append(report.Findings, *finding)
+				}
+				rec.Record(CheckEvent{RuleID: rule.ID, Scope: rule.Scope.String(), Ref: subj.Ref(), Outcome: outcome, Attrs: subj.Attributes(), Finding: finding})
+			}
+			continue
+		}
+		// Legacy path: rule provides Check only.
+		legacyFindings := rule.Check(ctx)
+		report.Findings = append(report.Findings, legacyFindings...)
+		for _, f := range legacyFindings {
+			rec.Record(CheckEvent{RuleID: rule.ID, Scope: "legacy", Ref: f.Location.String(), Outcome: "fail", Finding: &f})
+		}
+	}
+	return report
+}
+```
+
+- [ ] **Step 5:** Run existing tests.
+
+```bash
+go test ./...
+```
+
+Expected: all pass — the new code path is only exercised when CheckSubject is set, and no rule has it set yet.
+
+- [ ] **Step 6:** Commit.
+
+```bash
+git add check_event.go verify.go
+git commit -m "feat(verify): add per-subject framework iteration + CheckEvent recording"
+```
+
+---
+
+### Task 7: `--format jsonl` CLI flag
+
+**Files:**
+- Modify: `cmd/samfile/verify.go`
+
+- [ ] **Step 1:** Read existing `cmd/samfile/verify.go` to find the flag-parsing block.
+
+```bash
+grep -n "flag\." cmd/samfile/verify.go | head -20
+```
+
+- [ ] **Step 2:** Add a `--format` flag (string, default `"text"`). After flag parsing, if `format == "jsonl"`:
+
+```go
+rec := &samfile.EventRecorder{Disk: filepath.Base(input)}
+_ = di.VerifyWithRecorder(rec)
+enc := json.NewEncoder(os.Stdout)
+for _, ev := range rec.Events {
+    if err := enc.Encode(ev); err != nil {
+        return err
+    }
+}
+return nil
+```
+
+Otherwise the existing text path runs unchanged.
+
+- [ ] **Step 3:** Build and smoke-test.
+
+```bash
+go build -o /tmp/samfile-audit ./cmd/samfile
+/tmp/samfile-audit verify --format jsonl -i testdata/ETrackerv1.2.mgt | head -5
+```
+
+Expected: 0+ JSONL lines on stdout (all legacy events for now — they're "fail" events from existing rules).
+
+- [ ] **Step 4:** Commit.
+
+```bash
+git add cmd/samfile/verify.go
+git commit -m "feat(samfile): add --format jsonl flag to verify command"
+```
+
+---
+
+## Phase 2 — Rule migrations (one task per rule file)
+
+Each task migrates one rule file from `Check func(ctx) []Finding` to `Scope + Applies + CheckSubject`. The existing tests must still pass after migration. Per-rule pattern: extract the iteration that's currently inside the rule body into `Applies` (returns true when the subject is eligible — typically a type/dialect/state check), and reshape `Check`'s body to operate on the single passed-in Subject, returning `*Finding`.
+
+**Migration helper template:**
+
+```go
+Register(Rule{
+    ID:          "EXAMPLE-RULE",
+    Severity:    SeverityCosmetic,
+    Description: "...",
+    Citation:    "...",
+    Scope:       SlotScope,
+    Applies: func(ctx *CheckContext, subj Subject) bool {
+        s := subj.(*SlotSubject)
+        return s.FileEntry.Type == FT_CODE  // adjust per-rule
+    },
+    CheckSubject: func(ctx *CheckContext, subj Subject) *Finding {
+        s := subj.(*SlotSubject)
+        // ... existing per-slot check body ...
+        if mismatch {
+            return &Finding{RuleID: "EXAMPLE-RULE", Severity: SeverityCosmetic, Location: SlotLocation(s.SlotIndex, s.FileEntry.Name.String()), Message: ...}
+        }
+        return nil
+    },
+})
+```
+
+### Task 8: Migrate `rules_smoke.go` (1 rule)
+
+- [ ] **Step 1:** Migrate `DISK-NOT-EMPTY` to `Scope: DiskScope, Applies: always-true, CheckSubject: per-disk`.
+- [ ] **Step 2:** Run `go test ./...`. Expected: pass.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_smoke to per-subject framework`.
+
+### Task 9: Migrate `rules_disk.go` (3 rules)
+
+- [ ] **Step 1:** Migrate `DISK-DIRECTORY-TRACKS`, `DISK-TRACK-SIDE-ENCODING`, `DISK-SECTOR-RANGE`. All three are `DiskScope`. The two encoding/range rules iterate sectors internally — move that iteration to `ChainStepScope` if it makes sense, otherwise keep as `DiskScope` and walk internally.
+- [ ] **Step 2:** Run `go test ./rules_disk_test.go ./...`. Expected: pass.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_disk to per-subject framework`.
+
+### Task 10: Migrate `rules_directory.go` (9 rules)
+
+- [ ] **Step 1:** Migrate each rule. Most are `SlotScope` with `Applies` filtering on slot-state (used vs erased).
+- [ ] **Step 2:** Run tests.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_directory to per-subject framework`.
+
+### Task 11: Migrate `rules_chain.go` (4 rules)
+
+- [ ] **Step 1:** Migrate. `CHAIN-TERMINATOR-ZERO-ZERO`, `CHAIN-NO-CYCLE`, `CHAIN-MATCHES-SAM`: `ChainStepScope` makes sense for the first; the others are slot-scope (they reason about the whole chain). Pick the scope that produces the right denominator and use the chain-step or slot subject accordingly.
+- [ ] **Step 2:** Tests.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_chain to per-subject framework`.
+
+### Task 12: Migrate `rules_cross.go` (3 rules)
+
+- [ ] **Step 1:** Migrate. These are inherently disk-scope (compare across slots).
+- [ ] **Step 2:** Tests.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_cross to per-subject framework`.
+
+### Task 13: Migrate `rules_body_header.go` (11 rules)
+
+- [ ] **Step 1:** Migrate. All `SlotScope`. `Applies` filters: most need `Type != 0`; some FT_CODE-only (the EXEC-* rules already have this check inside).
+- [ ] **Step 2:** Tests.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_body_header to per-subject framework`.
+
+### Task 14: Migrate `rules_ft_code.go` (4 rules)
+
+- [ ] **Step 1:** Migrate. All `SlotScope`, `Applies: Type == FT_CODE`.
+- [ ] **Step 2:** Tests.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_ft_code to per-subject framework`.
+
+### Task 15: Migrate `rules_ft_basic.go` (7 rules)
+
+- [ ] **Step 1:** Migrate. All `SlotScope`, `Applies: Type == FT_SAM_BASIC`.
+- [ ] **Step 2:** Tests.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_ft_basic to per-subject framework`.
+
+### Task 16: Migrate `rules_ft_array.go` (1 rule)
+
+- [ ] **Step 1:** Migrate. `SlotScope`, `Applies: Type == FT_NUMERIC_ARRAY || Type == FT_STRING_ARRAY`.
+- [ ] **Step 2:** Tests.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_ft_array to per-subject framework`.
+
+### Task 17: Migrate `rules_ft_screen.go` (2 rules)
+
+- [ ] **Step 1:** Migrate. `SlotScope`, `Applies: Type == FT_SCREEN`.
+- [ ] **Step 2:** Tests.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_ft_screen to per-subject framework`.
+
+### Task 18: Migrate `rules_ft_zxsnap.go` (2 rules)
+
+- [ ] **Step 1:** Migrate. `SlotScope`, `Applies: Type == FT_ZX_SNAP_48K`.
+- [ ] **Step 2:** Tests.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_ft_zxsnap to per-subject framework`.
+
+### Task 19: Migrate `rules_boot.go` (3 rules)
+
+- [ ] **Step 1:** Migrate. `DiskScope`. `Applies: always-true`.
+- [ ] **Step 2:** Tests.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_boot to per-subject framework`.
+
+### Task 20: Migrate `rules_cosmetic.go` (1 rule)
+
+- [ ] **Step 1:** Migrate. Probably `DiskScope` or `SlotScope` depending on the rule body.
+- [ ] **Step 2:** Tests.
+- [ ] **Step 3:** Commit: `refactor(verify): migrate rules_cosmetic to per-subject framework`.
+
+---
+
+## Phase 3 — Python pipeline
+
+### Task 21: `tools/audit/ingest.py`
+
+**Files:**
+- Create: `tools/audit/ingest.py`
+
+- [ ] **Step 1:** Create `tools/audit/ingest.py`:
+
+```python
+#!/usr/bin/env python3
+"""Ingest JSONL CheckEvents from samfile --format jsonl into the
+`checks` table of ~/sam-corpus/findings.db.
+
+Reads: ~/sam-corpus/outputs-jsonl/<disk>.jsonl
+Writes: ~/sam-corpus/findings.db (creates / replaces `checks` table).
+Existing `disks` and `findings` tables are not touched.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+CORPUS = Path.home() / "sam-corpus"
+JSONL_DIR = CORPUS / "outputs-jsonl"
+DB = CORPUS / "findings.db"
+
+COLUMNS = [
+    "disk", "rule_id", "scope", "ref", "outcome",
+    # disk attrs
+    "dialect", "boot_signature_present", "used_slot_count",
+    # slot attrs
+    "slot_index", "filename", "file_type", "file_type_byte",
+    "file_length", "page_offset_form", "pages", "mgt_flags",
+    "first_track", "first_sector", "first_side",
+    "has_autorun_or_autoexec", "dir_mirror_populated",
+    "slot_is_erased", "file_type_info_hex", "sectors_count",
+    # chain-step attrs
+    "chain_position", "chain_index", "track", "sector", "side",
+    "next_track", "next_sector", "on_sam_map", "on_dir_sam_map",
+    "distance_from_dir_tracks",
+    # finding payload
+    "severity", "message", "citation",
+]
+
+
+def column_value(event: dict, col: str):
+    if col in ("disk", "rule_id", "scope", "ref", "outcome"):
+        return event.get(col)
+    attrs = event.get("attrs") or {}
+    if col in attrs:
+        v = attrs[col]
+        if isinstance(v, bool):
+            return int(v)
+        return v
+    finding = event.get("finding") or {}
+    if col == "severity":
+        return finding.get("Severity")
+    if col == "message":
+        return finding.get("Message")
+    if col == "citation":
+        return finding.get("Citation")
+    return None
+
+
+def main() -> None:
+    conn = sqlite3.connect(DB)
+    c = conn.cursor()
+    c.execute("DROP TABLE IF EXISTS checks")
+    column_decls = []
+    for col in COLUMNS:
+        # outcome / scope / file_type are TEXT; numerics stay INTEGER.
+        if col in ("disk", "rule_id", "scope", "ref", "outcome",
+                   "dialect", "filename", "file_type", "page_offset_form",
+                   "file_type_info_hex", "chain_position",
+                   "severity", "message", "citation"):
+            column_decls.append(f"{col} TEXT")
+        else:
+            column_decls.append(f"{col} INTEGER")
+    c.execute(f"CREATE TABLE checks ({', '.join(column_decls)})")
+    c.execute("CREATE INDEX idx_checks_rule ON checks(rule_id)")
+    c.execute("CREATE INDEX idx_checks_outcome ON checks(outcome)")
+    c.execute("CREATE INDEX idx_checks_disk ON checks(disk)")
+    c.execute("CREATE INDEX idx_checks_type ON checks(file_type)")
+    placeholders = ", ".join("?" for _ in COLUMNS)
+    insert = f"INSERT INTO checks ({', '.join(COLUMNS)}) VALUES ({placeholders})"
+    n = 0
+    for path in sorted(JSONL_DIR.glob("*.jsonl")):
+        for line in path.read_text().splitlines():
+            if not line.strip():
+                continue
+            event = json.loads(line)
+            event.setdefault("disk", path.stem)
+            row = [column_value(event, col) for col in COLUMNS]
+            c.execute(insert, row)
+            n += 1
+    conn.commit()
+    conn.close()
+    print(f"ingested {n} CheckEvents into {DB}")
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2:** Commit.
+
+```bash
+git add tools/audit/ingest.py
+git commit -m "feat(audit): add ingest.py — JSONL CheckEvents -> checks table"
+```
+
+---
+
+### Task 22: `tools/audit/mine.py` — fallback-floor reports (coverage + disk-health)
+
+**Files:**
+- Create: `tools/audit/mine.py`
+
+- [ ] **Step 1:** Create `tools/audit/mine.py` (initial version with the two fallback reports only):
+
+```python
+#!/usr/bin/env python3
+"""Generate audit reports from ~/sam-corpus/findings.db's `checks` table.
+
+Reports (written under ~/sam-corpus/analyses/):
+  Fallback floor (plain counts):
+    coverage.md     — per-rule applies/fails/fail-rate
+    disk-health.md  — per-disk findings + structural-pass-rate
+  Richer (best-effort, see Task 24):
+    conditional.md
+    disk-clusters.md
+    patterns.md
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pandas as pd
+
+CORPUS = Path.home() / "sam-corpus"
+DB = CORPUS / "findings.db"
+OUT = CORPUS / "analyses"
+
+
+def load_checks() -> pd.DataFrame:
+    conn = sqlite3.connect(DB)
+    df = pd.read_sql_query("SELECT * FROM checks", conn)
+    conn.close()
+    return df
+
+
+def report_coverage(checks: pd.DataFrame) -> None:
+    rows = []
+    for rule_id, grp in checks.groupby("rule_id"):
+        applicable = grp[grp["outcome"].isin(["pass", "fail"])]
+        fails = grp[grp["outcome"] == "fail"]
+        applies_n = len(applicable)
+        fails_n = len(fails)
+        disks = grp.loc[grp["outcome"] == "fail", "disk"].nunique()
+        rate = (100.0 * fails_n / applies_n) if applies_n else 0.0
+        sev = fails["severity"].mode().iloc[0] if not fails.empty else ""
+        rows.append((rule_id, sev, applies_n, fails_n, rate, disks))
+    df = pd.DataFrame(rows, columns=["rule_id", "severity", "applies", "fails", "fail_rate_pct", "disks_affected"])
+    df = df.sort_values("fail_rate_pct", ascending=False)
+    md = ["# Per-rule coverage and failure rate", ""]
+    md.append("| Rule | Severity | Applies | Fails | Fail-rate | Disks |")
+    md.append("|---|---|---:|---:|---:|---:|")
+    for _, r in df.iterrows():
+        md.append(f"| `{r.rule_id}` | {r.severity} | {r.applies} | {r.fails} | {r.fail_rate_pct:.1f}% | {r.disks_affected} |")
+    (OUT / "coverage.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'coverage.md'} ({len(df)} rules)")
+
+
+def report_disk_health(checks: pd.DataFrame) -> None:
+    rows = []
+    for disk, grp in checks.groupby("disk"):
+        total_findings = (grp["outcome"] == "fail").sum()
+        fatal = ((grp["outcome"] == "fail") & (grp["severity"] == "fatal")).sum()
+        structural = ((grp["outcome"] == "fail") & (grp["severity"] == "structural")).sum()
+        struct_checks = grp[(grp["outcome"].isin(["pass", "fail"])) & (grp["severity"].isin(["structural", "fatal"]) | grp["rule_id"].isin([]))]
+        # Use the per-rule severity from the catalog, not the per-finding severity, for the denominator.
+        # Workaround: count outcomes per-rule-severity by joining via rule severity table built from fails.
+        # Simpler: use all applicable checks where the rule produced a fail with severity fatal/structural anywhere in the corpus.
+        struct_pass = (struct_checks["outcome"] == "pass").sum()
+        struct_fail = (struct_checks["outcome"] == "fail").sum()
+        struct_rate = (struct_pass / (struct_pass + struct_fail)) if (struct_pass + struct_fail) else 1.0
+        distinct_rules_fired = grp.loc[grp["outcome"] == "fail", "rule_id"].nunique()
+        rows.append((disk, total_findings, fatal, structural, struct_rate, distinct_rules_fired))
+    df = pd.DataFrame(rows, columns=["disk", "total_findings", "fatal", "structural", "structural_pass_rate", "distinct_rules_fired"])
+    df = df.sort_values(["structural_pass_rate", "total_findings"], ascending=[True, False])
+    md = ["# Per-disk health", ""]
+    md.append("Sorted by structural pass-rate (worst first). Disks at the top are the candidate 'not really a disk' cluster.")
+    md.append("")
+    md.append("| Disk | Total findings | Fatal | Structural | Struct pass-rate | Distinct rules fired |")
+    md.append("|---|---:|---:|---:|---:|---:|")
+    for _, r in df.iterrows():
+        md.append(f"| {r.disk[:60]} | {r.total_findings} | {r.fatal} | {r.structural} | {r.structural_pass_rate:.2f} | {r.distinct_rules_fired} |")
+    (OUT / "disk-health.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'disk-health.md'} ({len(df)} disks)")
+
+
+def main() -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    checks = load_checks()
+    print(f"loaded {len(checks)} CheckEvents")
+    report_coverage(checks)
+    report_disk_health(checks)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2:** Commit.
+
+```bash
+git add tools/audit/mine.py
+git commit -m "feat(audit): add mine.py with coverage + disk-health fallback reports"
+```
+
+---
+
+### Task 23: `tools/audit/mine.py` — richer reports
+
+**Files:**
+- Modify: `tools/audit/mine.py`
+
+- [ ] **Step 1:** Append richer reports to `mine.py` and add their calls in `main()`:
+
+```python
+def report_conditional(checks: pd.DataFrame) -> None:
+    """Per-rule conditional fail-rate per attribute value vs baseline."""
+    attr_cols = [c for c in checks.columns if c not in ("disk", "rule_id", "scope", "ref", "outcome", "severity", "message", "citation")]
+    rows = []
+    for rule_id, grp in checks.groupby("rule_id"):
+        applicable = grp[grp["outcome"].isin(["pass", "fail"])]
+        if len(applicable) < 10:
+            continue
+        baseline = (applicable["outcome"] == "fail").mean()
+        for col in attr_cols:
+            if applicable[col].isna().all():
+                continue
+            for val, sub in applicable.groupby(col):
+                if len(sub) < 10:
+                    continue
+                cond = (sub["outcome"] == "fail").mean()
+                # surface only when conditional rate deviates strongly
+                if (cond in (0.0, 1.0)) or abs(cond - baseline) > 0.3:
+                    rows.append((rule_id, col, str(val), len(sub), baseline, cond, cond - baseline))
+    df = pd.DataFrame(rows, columns=["rule_id", "attribute", "value", "support", "baseline_fail_rate", "conditional_fail_rate", "delta"])
+    df = df.sort_values(["rule_id", "delta"], ascending=[True, False])
+    md = ["# Conditional failure rates per attribute", ""]
+    md.append("Surfaces (rule, attribute, value) combinations where the conditional fail-rate differs substantially from the rule's baseline. |delta| > 0.3 or conditional rate ∈ {0%, 100%}, support ≥ 10.")
+    md.append("")
+    md.append("| Rule | Attribute | Value | Support | Baseline | Conditional | Δ |")
+    md.append("|---|---|---|---:|---:|---:|---:|")
+    for _, r in df.iterrows():
+        md.append(f"| `{r.rule_id}` | {r.attribute} | {r.value} | {r.support} | {r.baseline_fail_rate*100:.1f}% | {r.conditional_fail_rate*100:.1f}% | {r.delta*100:+.1f}pp |")
+    (OUT / "conditional.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'conditional.md'} ({len(df)} rows)")
+
+
+def report_disk_clusters(checks: pd.DataFrame) -> None:
+    """Hierarchical clustering of disks by rule-fire vector."""
+    try:
+        from sklearn.cluster import AgglomerativeClustering
+    except ImportError:
+        (OUT / "disk-clusters.md").write_text("# Disk clusters\n\nsklearn not installed; skipping.\n")
+        return
+    pivot = (checks[checks["outcome"] == "fail"]
+             .pivot_table(index="disk", columns="rule_id", values="ref", aggfunc="count", fill_value=0))
+    if pivot.empty:
+        (OUT / "disk-clusters.md").write_text("# Disk clusters\n\nNo failure events to cluster.\n")
+        return
+    n_clusters = min(8, max(2, len(pivot) // 100))
+    cl = AgglomerativeClustering(n_clusters=n_clusters)
+    pivot["cluster"] = cl.fit_predict((pivot > 0).astype(int).values)
+    md = ["# Disk clusters by rule-fire pattern", ""]
+    for cid, grp in pivot.groupby("cluster"):
+        top_rules = (grp.drop(columns="cluster") > 0).sum().sort_values(ascending=False).head(5)
+        md.append(f"## Cluster {cid} — {len(grp)} disks")
+        md.append("")
+        md.append("Most-fired rules in this cluster:")
+        for rule, n in top_rules.items():
+            md.append(f"- `{rule}` ({n} of {len(grp)} disks)")
+        md.append("")
+        md.append("Example disks:")
+        for disk in list(grp.index)[:5]:
+            md.append(f"- {disk[:60]}")
+        md.append("")
+    (OUT / "disk-clusters.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'disk-clusters.md'} ({n_clusters} clusters)")
+
+
+def report_patterns(checks: pd.DataFrame) -> None:
+    """Per-rule decision-tree splits."""
+    try:
+        from sklearn.tree import DecisionTreeClassifier, export_text
+    except ImportError:
+        (OUT / "patterns.md").write_text("# Patterns\n\nsklearn not installed; skipping.\n")
+        return
+    attr_cols = [c for c in checks.columns if c not in ("disk", "rule_id", "scope", "ref", "outcome", "severity", "message", "citation", "filename", "file_type_info_hex", "ref")]
+    md = ["# Per-rule patterns (decision-tree splits)", ""]
+    for rule_id, grp in checks.groupby("rule_id"):
+        applicable = grp[grp["outcome"].isin(["pass", "fail"])].copy()
+        if len(applicable) < 50:
+            continue
+        y = (applicable["outcome"] == "fail").astype(int)
+        if y.nunique() < 2:
+            continue
+        X = applicable[attr_cols].copy()
+        # Coerce categoricals to category codes; coerce booleans to int.
+        for c in X.columns:
+            if X[c].dtype == object:
+                X[c] = X[c].astype("category").cat.codes
+            else:
+                X[c] = X[c].fillna(-1)
+        try:
+            tree = DecisionTreeClassifier(max_depth=4, min_samples_leaf=10).fit(X, y)
+        except ValueError:
+            continue
+        md.append(f"## `{rule_id}` (applies={len(applicable)}, fail-rate={y.mean()*100:.1f}%)")
+        md.append("")
+        md.append("```")
+        md.append(export_text(tree, feature_names=list(X.columns), max_depth=4).strip())
+        md.append("```")
+        md.append("")
+    (OUT / "patterns.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'patterns.md'}")
+```
+
+And update `main()`:
+
+```python
+def main() -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    checks = load_checks()
+    print(f"loaded {len(checks)} CheckEvents")
+    report_coverage(checks)
+    report_disk_health(checks)
+    try:
+        report_conditional(checks)
+    except Exception as e:
+        print(f"conditional.md failed: {e}")
+    try:
+        report_disk_clusters(checks)
+    except Exception as e:
+        print(f"disk-clusters.md failed: {e}")
+    try:
+        report_patterns(checks)
+    except Exception as e:
+        print(f"patterns.md failed: {e}")
+```
+
+- [ ] **Step 2:** Commit.
+
+```bash
+git add tools/audit/mine.py
+git commit -m "feat(audit): add conditional / disk-clusters / patterns reports (best-effort)"
+```
+
+---
+
+### Task 24: `tools/audit/run_audit.sh`
+
+**Files:**
+- Create: `tools/audit/run_audit.sh`
+
+- [ ] **Step 1:** Create:
+
+```bash
+#!/bin/bash
+# Rebuild samfile-verify, regenerate JSONL across the corpus,
+# ingest, and mine. Idempotent.
+set -euo pipefail
+
+REPO="${HOME}/git/samfile"
+CORPUS="${HOME}/sam-corpus"
+
+cd "$REPO"
+go build -o "$CORPUS/samfile-audit" ./cmd/samfile
+
+mkdir -p "$CORPUS/outputs-jsonl" "$CORPUS/analyses"
+rm -f "$CORPUS/outputs-jsonl"/*.jsonl
+
+count=0
+for disk in "$CORPUS/disks"/*.mgt; do
+    [ -f "$disk" ] || continue
+    name=$(basename "$disk" .mgt)
+    "$CORPUS/samfile-audit" verify --format jsonl -i "$disk" \
+        > "$CORPUS/outputs-jsonl/$name.jsonl" 2>/dev/null || true
+    count=$((count + 1))
+done
+echo "ran samfile-audit on $count disks"
+
+python3 "$REPO/tools/audit/ingest.py"
+python3 "$REPO/tools/audit/mine.py"
+echo "reports in $CORPUS/analyses/"
+```
+
+- [ ] **Step 2:** Mark executable.
+
+```bash
+chmod +x tools/audit/run_audit.sh
+```
+
+- [ ] **Step 3:** Commit.
+
+```bash
+git add tools/audit/run_audit.sh
+git commit -m "feat(audit): add run_audit.sh end-to-end driver"
+```
+
+---
+
+## Phase 4 — End-to-end run + autonomous discovery loop
+
+### Task 25: End-to-end smoke test on a few disks
+
+- [ ] **Step 1:** Build and run on 3 sample disks:
+
+```bash
+go build -o /tmp/samfile-audit ./cmd/samfile
+mkdir -p /tmp/audit-smoke
+for disk in ~/sam-corpus/disks/*.mgt; do
+    /tmp/samfile-audit verify --format jsonl -i "$disk" > "/tmp/audit-smoke/$(basename "$disk" .mgt).jsonl" 2>/dev/null
+    break
+done
+ls -la /tmp/audit-smoke/
+head -3 /tmp/audit-smoke/*.jsonl
+```
+
+Expected: at least one .jsonl file with valid JSON objects per line.
+
+- [ ] **Step 2:** Sanity-check that pass + fail + not_applicable counts make sense for one rule:
+
+```bash
+jq -s 'group_by(.rule_id) | map({rule:.[0].rule_id, total:length, fail:map(select(.outcome=="fail"))|length, pass:map(select(.outcome=="pass"))|length, na:map(select(.outcome=="not_applicable"))|length})' /tmp/audit-smoke/*.jsonl | head -40
+```
+
+Expected: per-rule pass + fail + n/a counts.
+
+### Task 26: Full corpus run
+
+- [ ] **Step 1:**
+
+```bash
+~/git/samfile/tools/audit/run_audit.sh
+```
+
+Expected: ~800 .jsonl files in `~/sam-corpus/outputs-jsonl/`, `checks` table populated, five Markdown reports in `~/sam-corpus/analyses/`.
+
+- [ ] **Step 2:** Eyeball `coverage.md` and `disk-health.md`. Sanity checks:
+  - High-fail-rate rules at the top: are they known cases? (e.g. for rules already known to be over-strict, do they appear?)
+  - Worst-health disks: do the same ~10 disks fire across most rules? That's the "broken disk cluster".
+
+### Task 27: Autonomous discovery + fix loop
+
+This is the iterative loop. For each pass:
+
+- [ ] **Step 1:** Read `coverage.md` + `conditional.md` + `patterns.md`. Identify high-confidence patterns per the spec's threshold:
+  - (statistical): conditional fail-rate ≥ 80% on support ≥ 10 distinct disks, OR conditional fail-rate = 0% on support ≥ 10, OR Apriori confidence=1.0 support ≥ 10
+  - (citation): a line range in `~/git/samdos/src/*.s`, ROM disasm, or samfile that explains the pattern
+
+- [ ] **Step 2:** For each high-confidence pattern:
+  - Form a hypothesis ("rule X mis-fires when attribute Y because rule Z is over-strict / under-strict")
+  - Open the cited source range and confirm the explanation
+  - If confirmed: patch the rule (catalog + verify code + tests). Commit with the citation in the commit message.
+  - If refuted: discard.
+  - If ambiguous: add to `~/sam-corpus/analyses/needs-human.md`.
+
+- [ ] **Step 3:** After acting on all high-confidence patterns, re-run:
+
+```bash
+~/git/samfile/tools/audit/run_audit.sh
+```
+
+- [ ] **Step 4:** If a new pass surfaces no new high-confidence patterns, stop. Otherwise return to Step 1.
+
+### Task 28: PR
+
+- [ ] **Step 1:** Push the branch.
+
+```bash
+git push -u origin feat/verify-audit-framework
+```
+
+- [ ] **Step 2:** Create draft PR.
+
+```bash
+gh pr create --draft --title "feat(verify): per-subject audit framework + corpus-driven rule fixes" --body "$(cat <<'EOF'
+## Summary
+
+Adds per-subject Check-event instrumentation to the verify pipeline, ingests events into `~/sam-corpus/findings.db`, and uses the resulting `checks` table to discover patterns that drive rule-fix decisions. Five Markdown reports produced under `~/sam-corpus/analyses/`. All rule fixes in this PR are grounded by source citations from SAMDOS / ROM disasm / samfile.
+
+Design spec: `docs/specs/2026-05-12-verify-audit-framework-design.md`.
+Implementation plan: `docs/plans/2026-05-12-verify-audit-framework.md`.
+
+## Framework changes
+
+- `subject.go`, `subject_disk.go`, `subject_slot.go`, `subject_chain.go` — Subject interface + three scope-specific implementations.
+- `verify.go` — extended `Rule` struct with `Scope` + `Applies` + `CheckSubject`; framework iterates subjects per scope and records `CheckEvent`s.
+- `check_event.go` — CheckEvent + EventRecorder.
+- `cmd/samfile/verify.go` — new `--format jsonl` flag.
+- All N rules migrated from `Check func(ctx) []Finding` to `Scope + Applies + CheckSubject`. Existing tests pass.
+
+## Python pipeline
+
+- `tools/audit/ingest.py` — JSONL → `checks` SQLite table.
+- `tools/audit/mine.py` — five reports (coverage, disk-health, conditional, disk-clusters, patterns).
+- `tools/audit/run_audit.sh` — end-to-end driver.
+
+## Rule fixes
+
+(Filled in by the autonomous loop; each commit cites the source range that grounded the fix.)
+
+## Test plan
+
+- [ ] `go test ./...` passes
+- [ ] `samfile verify --format jsonl -i testdata/ETrackerv1.2.mgt` emits valid JSONL
+- [ ] `tools/audit/run_audit.sh` runs end-to-end on the local corpus
+- [ ] Reports under `~/sam-corpus/analyses/` look coherent
+- [ ] CI green
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3:** Monitor CI until all checks complete. Fix failures autonomously (amend the responsible commit, force-push). Leave the PR as draft for Pete's review.
+
+---
+
+## Self-review
+
+- All tasks reference exact file paths.
+- All code-touching steps include the code to write.
+- Each task ends in a commit.
+- Migration tasks group rules by file (review unit = one file's worth of rules).
+- The autonomous loop (Task 27) is explicit about when to stop and what counts as "act-on" confidence.
+- The plan covers every section of the spec: Subject schema (Tasks 1-4), Rule struct + framework (Tasks 5-7), JSONL CLI (Task 7), migration (Tasks 8-20), Python ingest (Task 21), reports including fallback floor (Tasks 22-23), driver (Task 24), end-to-end (Tasks 25-26), discovery/fix loop (Task 27), PR (Task 28).

--- a/docs/specs/2026-05-12-verify-audit-framework-design.md
+++ b/docs/specs/2026-05-12-verify-audit-framework-design.md
@@ -1,0 +1,329 @@
+# Verify Audit Framework — Design Spec
+
+**Date:** 2026-05-12
+**Status:** Draft (pre-implementation)
+
+## Problem
+
+Today's verify pipeline emits findings (failures) but not checks (attempts). Three consequences:
+
+1. **No denominators.** A rule that fires 100 times looks the same whether it was applicable 100 times (100% fail) or 100,000 times (0.1%). Today we can't tell.
+2. **No per-check context.** We don't capture which subjects were checked, what their attributes were, or what passed. So we can't ask "is this rule only failing on samdos2 disks?" or "does this fire on every ZX snapshot?".
+3. **No association analysis.** Without (subject × rule × outcome × attributes) rows, we can't mine for patterns like "fails when file_type=ZX_SNAP AND first_track=4". Today's investigation is anecdotal — find a finding, eyeball it, guess.
+
+The corpus-reclassification work (`docs/notes/corpus-reclassification-2026-05-12.md`) compensated by manual SQL queries, but every reclassification decision relied on guessing whether the residual fires were "real signal" or "noise from broken disks". With ~50 rules and ~250K potential checks across the 800-disk corpus, this doesn't scale.
+
+## Goal
+
+Build infrastructure that:
+
+1. Records every check (pass and fail) with a full per-subject attribute snapshot.
+2. Lets us compute pass-rate and conditional fail-rate slices trivially in pandas.
+3. Surfaces patterns ("rule X fails 100% of the time when feature Y = Z") with high enough confidence to drive rule-fix decisions.
+4. Reuses across rule changes — every catalog edit gets a fresh audit run.
+
+The endpoint is not the framework. The endpoint is: **a small set of catalog and code fixes grounded in source code (samdos / ROM disasm / samfile) and validated against this corpus**.
+
+## Non-goals
+
+- Real-time / interactive verify. Batch only.
+- Deep learning. Classical pandas + sklearn + mlxtend is sufficient at 800-disk scale.
+- A new web UI. Markdown reports + SQLite for ad-hoc queries.
+- Generalizing beyond MGT disks.
+
+## Decisions (from brainstorming)
+
+| Choice | Decision |
+|---|---|
+| Lifespan | Ongoing infrastructure (re-runs after every rule change). |
+| Code split | Go-side instrumentation in samfile repo; Python analysis in `~/sam-corpus/`. |
+| Instrumentation style | Rule struct grows `Applies(subject) → bool` + `Scope` field; framework drives iteration and emits per-subject Check events. |
+| Output format from samfile | `samfile verify --format jsonl` emits one JSON object per Check; default text output unchanged. |
+| Pattern-mining stack | pandas + sklearn `DecisionTreeClassifier` + mlxtend `apriori` / `association_rules`. |
+| PR strategy | One bundled draft PR: framework + all rule fixes. |
+| Stop conditions | Loop until a pass produces no high-confidence patterns. Ambiguous patterns documented under `needs-human` and skipped. |
+| ROM disasm source | `~/git/sam-aarch64/docs/sam/sam-coupe_rom-v3.0_annotated-disassembly.txt`. |
+
+## Architecture
+
+```
+[800 disks] ──► samfile verify ──JSONL──► sam-corpus/ingest.py ──► findings.db
+              (rules emit Check events                              ├ checks  (new)
+              for pass + fail + N/A)                                ├ findings (kept)
+                                                                    └ disks   (kept)
+                                                                       │
+                                                                       ▼
+                                                          sam-corpus/mine.py
+                                                          ├ coverage.md       (fallback floor)
+                                                          ├ disk-health.md    (fallback floor)
+                                                          ├ conditional.md
+                                                          ├ disk-clusters.md
+                                                          └ patterns.md
+                                                                       │
+                                                                       ▼
+                                                          autonomous fix loop
+                                                          (hypothesis → source-ground → fix → re-run)
+```
+
+Four stages with clean boundaries:
+
+1. **Go-side instrumentation** (samfile): rules declare scope + applicability; framework drives iteration; emits Check events.
+2. **JSONL emission** (samfile): new `--format jsonl` CLI flag.
+3. **Ingest** (sam-corpus/Python): JSONL → `checks` SQLite table with denormalized attribute columns.
+4. **Mine + report** (sam-corpus/Python): five Markdown reports + a SQLite database for ad-hoc queries.
+
+## Attribute schema
+
+Three subject scopes; framework records `(scope, ref, outcome, attrs)` per check.
+
+### Disk-scope
+
+Per disk:
+- `sha256`
+- `dialect` (`samdos` / `samdos2` / `masterdos` / `other`)
+- `boot_signature_present` (bool)
+- `used_slot_count`
+- `free_sector_count`
+- `sector_map_populated_pct`
+- `total_findings_fatal`, `total_findings_structural`, `total_findings_inconsistency`, `total_findings_cosmetic`
+- `source_label` (from `manifest.csv`)
+
+### Slot-scope
+
+Per directory entry (0..79):
+- `slot_index`
+- `filename`
+- `file_type` (decoded constant name, e.g. `FT_CODE`, `FT_SAM_BASIC`, `FT_SCREEN`, `FT_ARRAY`, `FT_ZX_SNAP`)
+- `file_type_byte` (raw 0..255)
+- `file_length` (decoded `LengthMod16K`)
+- `page_offset_form` (`0x8000` / `0x4000` / `other`)
+- `pages`
+- `mgt_flags`
+- `chain_length` (sector count)
+- `sectors_count` (dir field, for cross-check vs chain)
+- `first_track`, `first_sector`, `first_side` (0/1)
+- `has_autorun_or_autoexec` (bool — auto-RUN line set for BASIC, auto-exec address set for CODE)
+- `dir_mirror_populated` (bool — dir 0xD3..0xDB non-zero)
+- `slot_is_erased` (Type==0)
+- `file_type_info_hex` (FileTypeInfo bytes, hex string)
+
+### Chain-step-scope
+
+Per sector in a file's chain:
+- `slot_index` (which file)
+- `chain_position` (`first` / `intermediate` / `last` / `orphan`)
+- `chain_index` (0..N-1)
+- `track`, `sector`, `side`
+- `next_track`, `next_sector`
+- `on_sam_map` (bool — appears in side-0 / side-1 SAM sector-allocation maps)
+- `on_dir_sam_map` (bool — appears in this dir entry's SectorAddressMap)
+- `distance_from_dir_tracks` (min cylinder distance to tracks 0..3)
+
+## Go-side changes (samfile repo)
+
+### `Rule` struct refactor
+
+Add `Scope` and `Applies`; change `Check` signature so it operates on one subject at a time and returns nil for pass.
+
+```go
+type SubjectScope int
+
+const (
+    DiskScope SubjectScope = iota
+    SlotScope
+    ChainStepScope
+)
+
+type Subject interface {
+    Ref() string                  // e.g. "slot=5" or "track=4,sector=1"
+    Attributes() map[string]any   // denormalized attribute snapshot
+}
+
+type Rule struct {
+    ID          string
+    Description string
+    Severity    Severity
+    Citation    string
+    Scope       SubjectScope
+    Applies     func(*CheckContext, Subject) bool   // NEW
+    Check       func(*CheckContext, Subject) *Finding // NEW signature
+}
+```
+
+### Framework
+
+The verify driver enumerates subjects for each rule's scope, calls `Applies`, and on true calls `Check`. Per (rule, subject) it emits a `CheckEvent`:
+
+```go
+type CheckEvent struct {
+    Version  int                    `json:"v"`
+    Disk     string                 `json:"disk"`
+    RuleID   string                 `json:"rule_id"`
+    Scope    string                 `json:"scope"`
+    Ref      string                 `json:"ref"`
+    Outcome  string                 `json:"outcome"`  // pass | fail | not_applicable
+    Attrs    map[string]any         `json:"attrs"`
+    Finding  *Finding               `json:"finding,omitempty"`
+}
+```
+
+The existing 51 rules each receive a mechanical refactor: extract the iteration logic (currently embedded in each rule's check function) into `Applies`, and reshape the check body to operate on one subject. Typical change is ~5 lines per rule.
+
+### CLI
+
+```
+samfile verify --format jsonl -i disk.mgt > disk.jsonl
+samfile verify -i disk.mgt                    # unchanged text output
+```
+
+Default behaviour preserved. JSONL is opt-in.
+
+### Tests
+
+- Each refactored rule keeps its existing unit tests, exercised through the new `Applies` / `Check` pair.
+- New framework-level test asserting that `not_applicable` + `pass` + `fail` counts sum to the universe of subjects for that scope.
+
+## Python-side changes (`~/sam-corpus/`)
+
+### `ingest.py`
+
+Reads `outputs-jsonl/*.jsonl` (one file per corpus disk), writes a new `checks` table to `findings.db`. Schema:
+
+```sql
+CREATE TABLE checks (
+    disk TEXT,
+    rule_id TEXT,
+    scope TEXT,
+    ref TEXT,
+    outcome TEXT,              -- 'pass' | 'fail' | 'not_applicable'
+    -- denormalized disk attributes
+    dialect TEXT,
+    boot_signature_present INTEGER,
+    used_slot_count INTEGER,
+    -- denormalized slot attributes (NULL if disk-scope)
+    slot_index INTEGER,
+    file_type TEXT,
+    file_type_byte INTEGER,
+    file_length INTEGER,
+    page_offset_form TEXT,
+    first_track INTEGER,
+    first_sector INTEGER,
+    first_side INTEGER,
+    has_autorun_or_autoexec INTEGER,
+    dir_mirror_populated INTEGER,
+    chain_length INTEGER,
+    -- denormalized chain-step attributes (NULL if disk/slot-scope)
+    chain_position TEXT,
+    chain_index INTEGER,
+    track INTEGER,
+    sector INTEGER,
+    side INTEGER,
+    on_sam_map INTEGER,
+    on_dir_sam_map INTEGER,
+    -- finding payload (NULL if pass / not_applicable)
+    severity TEXT,
+    message TEXT,
+    citation TEXT
+);
+CREATE INDEX idx_checks_rule ON checks(rule_id);
+CREATE INDEX idx_checks_outcome ON checks(outcome);
+CREATE INDEX idx_checks_disk ON checks(disk);
+```
+
+`disks` and `findings` tables stay; existing `analyze.py` keeps working.
+
+### `mine.py`
+
+Emits five Markdown reports under `~/sam-corpus/analyses/`. Reports are produced in fail-safe order — the two fallback-floor reports first, then richer analyses.
+
+#### Fallback floor (must always succeed)
+
+**`coverage.md` — per-rule priority report:**
+
+| Rule | Severity | Applies | Fails | Fail-rate | Disks affected |
+|---|---|---:|---:|---:|---:|
+
+Sorted by fail-rate desc. Plain pandas groupby; no clustering, no ML.
+
+**`disk-health.md` — per-disk priority report:**
+
+| Disk | Total findings | Fatal | Structural | Structural pass-rate | Distinct rules fired |
+|---|---:|---:|---:|---:|---:|
+
+`structural_pass_rate` = `passes / (passes + fails)` over checks where the rule severity is `structural`. Sorted asc — worst disks first. Disks with `structural_pass_rate < 0.5` and high `distinct_rules_fired` are the candidate "not really a disk" cluster.
+
+#### Richer analyses (best-effort, graceful failure)
+
+**`conditional.md`:** per-rule, table of `(attribute, value, conditional_fail_rate, baseline_fail_rate, support, Z-score)`. Rows surface only when `|Z| > 2` OR `conditional_fail_rate ∈ {0%, 100%}` OR `support ≥ 10`.
+
+**`disk-clusters.md`:** hierarchical clustering of disks by rule-fire pattern (sklearn `AgglomerativeClustering`). Co-occurrence matrix between rules with Jaccard ≥ 0.7. Surfaces the "totally broken disks" cluster explicitly.
+
+**`patterns.md`:** per-rule `DecisionTreeClassifier(max_depth=4)` trained on attributes → fail/pass; emits human-readable splits. Apriori-mined association rules at confidence ≥ 0.9, support ≥ 10 distinct disks.
+
+Each rich report ends with a **`needs-human`** section: patterns where signal is real but I cannot find a source-code citation that confirms the explanation.
+
+### `run_audit.sh` (in samfile `tools/audit/`)
+
+```
+1. cd ~/git/samfile && go build -o ~/sam-corpus/samfile-audit ./cmd/samfile
+2. cd ~/sam-corpus && mkdir -p outputs-jsonl analyses
+3. for disk in disks/*.mgt; do
+     ~/sam-corpus/samfile-audit verify --format jsonl -i "$disk" \
+       > "outputs-jsonl/$(basename "$disk" .mgt).jsonl"
+   done
+4. python3 ~/git/samfile/tools/audit/ingest.py
+5. python3 ~/git/samfile/tools/audit/mine.py
+```
+
+Idempotent — re-runnable on every framework or rule change.
+
+## Autonomous fix loop
+
+After the framework PR's code is in place and reports run, the loop:
+
+```
+1. Run analyses.
+2. For each high-confidence pattern:
+     a. Form hypothesis.
+     b. Read source (~/git/samdos/src/*.s + ROM disasm + samfile.go + rules_*.go).
+     c. Confirm or refute. If confirmed AND fix is unambiguous → patch the rule on the feature branch.
+     d. If refuted → discard. If ambiguous → append to needs-human.md.
+3. Re-run analyses.
+4. If new high-confidence patterns surface, go to 2. Else stop.
+```
+
+**High-confidence threshold (both required):**
+
+(a) Statistical signal: one of
+    - `conditional_fail_rate ≥ 80%` on a non-trivial slice (support ≥ 10 distinct disks)
+    - `conditional_fail_rate = 0%` on a non-trivial slice (support ≥ 10)
+    - Apriori association rule with `confidence = 1.0`, `support ≥ 10 distinct disks`
+
+(b) Citation: a line range in `~/git/samdos/src/*.s` or the ROM disasm or `samfile.go` whose semantics, when read in context, explain the pattern.
+
+Patterns missing either criterion → `needs-human.md`. Never act without both.
+
+## PR / branch
+
+Single feature branch `feat/verify-audit-framework`. Single draft PR containing:
+
+- The Go-side framework refactor.
+- All 51 rules refactored.
+- The JSONL CLI flag.
+- Python tooling under `tools/audit/` in the samfile repo (`ingest.py`, `mine.py`, `run_audit.sh`) — version controlled, ships with the PR. `~/sam-corpus/` is the runtime workspace where disks, JSONL outputs, and the SQLite DB live; the audit scripts are invoked from there. Existing `~/sam-corpus/{gather,analyze}.py` are untouched.
+- All rule-fix commits, each with citations to source.
+- Updated catalog (`docs/disk-validity-rules.md`) where rule semantics change.
+- A summary report in the PR body linking to the five analysis reports.
+
+Draft remains draft until user review. Standard CLAUDE.md global rules apply (monitor CI, fix failures autonomously, never mark ready without explicit approval).
+
+## Risks
+
+- **Framework refactor scope.** Touching all 51 rules is large. Mitigation: mechanical per-rule shape change; each rule keeps its tests; CI gates the framework PR.
+- **Hallucinated grounding.** I could "find" a citation that doesn't actually support the rule fix. Mitigation: every rule-fix commit must quote the source line range verbatim in the commit message; user reviews diff before merge.
+- **Pattern-mining noise.** Decision trees and Apriori can produce spurious rules at small support. Mitigation: high support + confidence thresholds; fallback-floor reports stand alone if richer reports turn noisy.
+- **Loop divergence.** Re-running could surface infinite "patterns" that are all artifacts of earlier fixes. Mitigation: stop condition is strict (no NEW high-confidence patterns).
+
+## Open questions for user review
+
+None at design time. Implementation may surface choices that need a call; those land in needs-human.md rather than blocking.

--- a/rules_applicability_helpers.go
+++ b/rules_applicability_helpers.go
@@ -1,0 +1,36 @@
+package samfile
+
+// Shared Applicability.Filter helpers used by rule registrations.
+// usedSlot accepts every SlotSubject whose dir entry has a non-zero
+// type byte (the standard "used file" set). typedSlot returns a
+// filter that further narrows to one or more specific file types.
+
+// usedSlot returns true when s is a SlotSubject whose FileEntry has
+// a non-zero type byte — i.e. the slot is considered occupied by
+// SAMDOS's free-slot test (type byte == 0).
+func usedSlot(ctx *CheckContext, s Subject) bool {
+	ss, ok := s.(*SlotSubject)
+	if !ok || ss.FileEntry == nil {
+		return false
+	}
+	return ss.FileEntry.Type != 0
+}
+
+// typedSlot returns a Filter that accepts a SlotSubject only when
+// its FileEntry's Type matches one of the provided file types. Used
+// by rules that apply to a specific file-type family (e.g. all
+// FT_CODE rules, the array-pair rule, etc.).
+func typedSlot(types ...FileType) func(*CheckContext, Subject) bool {
+	return func(ctx *CheckContext, s Subject) bool {
+		ss, ok := s.(*SlotSubject)
+		if !ok || ss.FileEntry == nil {
+			return false
+		}
+		for _, t := range types {
+			if ss.FileEntry.Type == t {
+				return true
+			}
+		}
+		return false
+	}
+}

--- a/rules_body_header.go
+++ b/rules_body_header.go
@@ -66,11 +66,12 @@ func bodyDirMirrorFinding(
 // has zero load-time consequence.
 func init() {
 	Register(Rule{
-		ID:          "BODY-TYPE-MATCHES-DIR",
-		Severity:    SeverityCosmetic,
-		Description: "body header Type byte equals directory-entry Type (attribute bits masked)",
-		Citation:    "samdos/src/c.s:1395-1408",
-		Check:       checkBodyTypeMatchesDir,
+		ID:            "BODY-TYPE-MATCHES-DIR",
+		Severity:      SeverityCosmetic,
+		Description:   "body header Type byte equals directory-entry Type (attribute bits masked)",
+		Citation:      "samdos/src/c.s:1395-1408",
+		Check:         checkBodyTypeMatchesDir,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -109,11 +110,12 @@ func checkBodyTypeMatchesDir(ctx *CheckContext) []Finding {
 // auto-exec from page 0 even though dir disables auto-exec.
 func init() {
 	Register(Rule{
-		ID:          "BODY-EXEC-DIV16K-MATCHES-DIR",
-		Severity:    SeverityStructural,
-		Description: "FT_CODE body-header ExecutionAddressDiv16K (byte 5) equals dir-entry ExecutionAddressDiv16K (skipped when body[5]==0xFF — the canonical 'defer to dir' pattern)",
-		Citation:    "rom-disasm:22471-22484",
-		Check:       checkBodyExecDiv16KMatchesDir,
+		ID:            "BODY-EXEC-DIV16K-MATCHES-DIR",
+		Severity:      SeverityStructural,
+		Description:   "FT_CODE body-header ExecutionAddressDiv16K (byte 5) equals dir-entry ExecutionAddressDiv16K (skipped when body[5]==0xFF — the canonical 'defer to dir' pattern)",
+		Citation:      "rom-disasm:22471-22484",
+		Check:         checkBodyExecDiv16KMatchesDir,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_CODE)},
 	})
 }
 
@@ -156,11 +158,12 @@ func checkBodyExecDiv16KMatchesDir(ctx *CheckContext) []Finding {
 // an exec address.
 func init() {
 	Register(Rule{
-		ID:          "BODY-EXEC-MOD16K-LO-MATCHES-DIR",
-		Severity:    SeverityInconsistency,
-		Description: "FT_CODE body-header ExecutionAddressMod16KLo (byte 6) equals low byte of dir-entry ExecutionAddressMod16K (skipped when body[5]==0xFF — body byte 6 is meaningless under the 'defer to dir' pattern)",
-		Citation:    "rom-disasm:22472",
-		Check:       checkBodyExecMod16KLoMatchesDir,
+		ID:            "BODY-EXEC-MOD16K-LO-MATCHES-DIR",
+		Severity:      SeverityInconsistency,
+		Description:   "FT_CODE body-header ExecutionAddressMod16KLo (byte 6) equals low byte of dir-entry ExecutionAddressMod16K (skipped when body[5]==0xFF — body byte 6 is meaningless under the 'defer to dir' pattern)",
+		Citation:      "rom-disasm:22472",
+		Check:         checkBodyExecMod16KLoMatchesDir,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_CODE)},
 	})
 }
 
@@ -196,11 +199,12 @@ func checkBodyExecMod16KLoMatchesDir(ctx *CheckContext) []Finding {
 // load path via gtfle/hconr/txhed.
 func init() {
 	Register(Rule{
-		ID:          "BODY-PAGES-MATCHES-DIR",
-		Severity:    SeverityCosmetic,
-		Description: "body header Pages (byte 7) equals dir-entry Pages",
-		Citation:    "samdos/src/c.s:1376-1379",
-		Check:       checkBodyPagesMatchesDir,
+		ID:            "BODY-PAGES-MATCHES-DIR",
+		Severity:      SeverityCosmetic,
+		Description:   "body header Pages (byte 7) equals dir-entry Pages",
+		Citation:      "samdos/src/c.s:1376-1379",
+		Check:         checkBodyPagesMatchesDir,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -227,11 +231,12 @@ func checkBodyPagesMatchesDir(ctx *CheckContext) []Finding {
 // the dir entry via uifa+31 → page1 through hconr (h.s:346-347).
 func init() {
 	Register(Rule{
-		ID:          "BODY-STARTPAGE-MATCHES-DIR",
-		Severity:    SeverityCosmetic,
-		Description: "body header StartPage (byte 8) equals dir-entry StartAddressPage",
-		Citation:    "samdos/src/c.s:1376-1379",
-		Check:       checkBodyStartPageMatchesDir,
+		ID:            "BODY-STARTPAGE-MATCHES-DIR",
+		Severity:      SeverityCosmetic,
+		Description:   "body header StartPage (byte 8) equals dir-entry StartAddressPage",
+		Citation:      "samdos/src/c.s:1376-1379",
+		Check:         checkBodyStartPageMatchesDir,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -258,11 +263,12 @@ func checkBodyStartPageMatchesDir(ctx *CheckContext) []Finding {
 // the load path uses.
 func init() {
 	Register(Rule{
-		ID:          "BODY-LENGTHMOD16K-MATCHES-DIR",
-		Severity:    SeverityCosmetic,
-		Description: "body header LengthMod16K (bytes 1-2 LE) equals dir-entry LengthMod16K",
-		Citation:    "samdos/src/c.s:1376-1379",
-		Check:       checkBodyLengthMod16KMatchesDir,
+		ID:            "BODY-LENGTHMOD16K-MATCHES-DIR",
+		Severity:      SeverityCosmetic,
+		Description:   "body header LengthMod16K (bytes 1-2 LE) equals dir-entry LengthMod16K",
+		Citation:      "samdos/src/c.s:1376-1379",
+		Check:         checkBodyLengthMod16KMatchesDir,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -294,11 +300,12 @@ func checkBodyLengthMod16KMatchesDir(ctx *CheckContext) []Finding {
 // (h.s:349-350) populates hd0d1 from on the load path.
 func init() {
 	Register(Rule{
-		ID:          "BODY-PAGEOFFSET-MATCHES-DIR",
-		Severity:    SeverityCosmetic,
-		Description: "body header PageOffset (bytes 3-4 LE) equals dir-entry StartAddressPageOffset",
-		Citation:    "samdos/src/c.s:1376-1379",
-		Check:       checkBodyPageOffsetMatchesDir,
+		ID:            "BODY-PAGEOFFSET-MATCHES-DIR",
+		Severity:      SeverityCosmetic,
+		Description:   "body header PageOffset (bytes 3-4 LE) equals dir-entry StartAddressPageOffset",
+		Citation:      "samdos/src/c.s:1376-1379",
+		Check:         checkBodyPageOffsetMatchesDir,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -342,11 +349,12 @@ func checkBodyPageOffsetMatchesDir(ctx *CheckContext) []Finding {
 // is irreconcilable with "buggy writer" framing.
 func init() {
 	Register(Rule{
-		ID:          "BODY-MIRROR-AT-DIR-D3-DB",
-		Severity:    SeverityCosmetic,
-		Description: "dir bytes 0xD3..0xDB mirror body header bytes 0..8 (and dir byte 0xD2 is 0)",
-		Citation:    "samdos/src/f.s:462-471",
-		Check:       checkBodyMirrorAtDirD3DB,
+		ID:            "BODY-MIRROR-AT-DIR-D3-DB",
+		Severity:      SeverityCosmetic,
+		Description:   "dir bytes 0xD3..0xDB mirror body header bytes 0..8 (and dir byte 0xD2 is 0)",
+		Citation:      "samdos/src/f.s:462-471",
+		Check:         checkBodyMirrorAtDirD3DB,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -393,11 +401,12 @@ func checkBodyMirrorAtDirD3DB(ctx *CheckContext) []Finding {
 // a useful corpus-validation signal.
 func init() {
 	Register(Rule{
-		ID:          "BODY-PAGEOFFSET-8000H-FORM",
-		Severity:    SeverityCosmetic,
-		Description: "body-header PageOffset has bit 15 set (8000H-form convention)",
-		Citation:    "sam-coupe_tech-man_v3-0.txt:3037-3052",
-		Check:       checkBodyPageOffset8000HForm,
+		ID:            "BODY-PAGEOFFSET-8000H-FORM",
+		Severity:      SeverityCosmetic,
+		Description:   "body-header PageOffset has bit 15 set (8000H-form convention)",
+		Citation:      "sam-coupe_tech-man_v3-0.txt:3037-3052",
+		Check:         checkBodyPageOffset8000HForm,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -431,11 +440,12 @@ func checkBodyPageOffset8000HForm(ctx *CheckContext) []Finding {
 // marker, e.g. by SAMBASIC). Real on-disk load addresses use 0..30.
 func init() {
 	Register(Rule{
-		ID:          "BODY-PAGE-LE-31",
-		Severity:    SeverityStructural,
-		Description: "body-header StartPage's low 5 bits encode an on-disk page index (0..30)",
-		Citation:    "samfile.go:248-249",
-		Check:       checkBodyPageLE31,
+		ID:            "BODY-PAGE-LE-31",
+		Severity:      SeverityStructural,
+		Description:   "body-header StartPage's low 5 bits encode an on-disk page index (0..30)",
+		Citation:      "samfile.go:248-249",
+		Check:         checkBodyPageLE31,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -470,11 +480,12 @@ func checkBodyPageLE31(ctx *CheckContext) []Finding {
 // the rule documents the {FF, FF} convention.
 func init() {
 	Register(Rule{
-		ID:          "BODY-BYTES-5-6-CANONICAL-FF",
-		Severity:    SeverityCosmetic,
-		Description: "when body[5]==0xFF (no auto-exec), real SAVE writes body[6]==0xFF too",
-		Citation:    "rom-disasm:22076-22080",
-		Check:       checkBodyBytes56CanonicalFF,
+		ID:            "BODY-BYTES-5-6-CANONICAL-FF",
+		Severity:      SeverityCosmetic,
+		Description:   "when body[5]==0xFF (no auto-exec), real SAVE writes body[6]==0xFF too",
+		Citation:      "rom-disasm:22076-22080",
+		Check:         checkBodyBytes56CanonicalFF,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 

--- a/rules_boot.go
+++ b/rules_boot.go
@@ -41,11 +41,12 @@ func bootSlot(dj *DiskJournal) (slot int, fe *FileEntry, found bool) {
 // catalog severity is structural (bootability), not fatal.
 func init() {
 	Register(Rule{
-		ID:          "BOOT-OWNER-AT-T4S1",
-		Severity:    SeverityStructural,
-		Description: "some used directory entry has FirstSector (4, 1) so the disk is bootable on SAM hardware",
-		Citation:    "rom-disasm:20473-20598",
-		Check:       checkBootOwnerAtT4S1,
+		ID:            "BOOT-OWNER-AT-T4S1",
+		Severity:      SeverityStructural,
+		Description:   "some used directory entry has FirstSector (4, 1) so the disk is bootable on SAM hardware",
+		Citation:      "rom-disasm:20473-20598",
+		Check:         checkBootOwnerAtT4S1,
+		Applicability: &RuleApplicability{Scope: DiskScope},
 	})
 }
 
@@ -76,11 +77,12 @@ func checkBootOwnerAtT4S1(ctx *CheckContext) []Finding {
 // (bootability), not fatal.
 func init() {
 	Register(Rule{
-		ID:          "BOOT-SIGNATURE-AT-256",
-		Severity:    SeverityStructural,
-		Description: "T4S1 bytes 256-259 spell \"BOOT\" (case-insensitive, bit 7 ignored)",
-		Citation:    "rom-disasm:20582-20598",
-		Check:       checkBootSignatureAt256,
+		ID:            "BOOT-SIGNATURE-AT-256",
+		Severity:      SeverityStructural,
+		Description:   "T4S1 bytes 256-259 spell \"BOOT\" (case-insensitive, bit 7 ignored)",
+		Citation:      "rom-disasm:20582-20598",
+		Check:         checkBootSignatureAt256,
+		Applicability: &RuleApplicability{Scope: DiskScope},
 	})
 }
 
@@ -121,11 +123,12 @@ func checkBootSignatureAt256(ctx *CheckContext) []Finding {
 // are useful negative signals. Cosmetic per the catalog's test sketch.
 func init() {
 	Register(Rule{
-		ID:          "BOOT-ENTRY-POINT-AT-9",
-		Severity:    SeverityCosmetic,
-		Description: "T4S1 body byte 0 (sector offset 9) is not 0x00 or 0xFF — a heuristic plausibility check for Z80 boot code",
-		Citation:    "rom-disasm:20598",
-		Check:       checkBootEntryPointAt9,
+		ID:            "BOOT-ENTRY-POINT-AT-9",
+		Severity:      SeverityCosmetic,
+		Description:   "T4S1 body byte 0 (sector offset 9) is not 0x00 or 0xFF — a heuristic plausibility check for Z80 boot code",
+		Citation:      "rom-disasm:20598",
+		Check:         checkBootEntryPointAt9,
+		Applicability: &RuleApplicability{Scope: DiskScope},
 	})
 }
 

--- a/rules_chain.go
+++ b/rules_chain.go
@@ -71,11 +71,12 @@ func walkChain(di *DiskImage, first *Sector) chainWalkResult {
 // ----- CHAIN-TERMINATOR-ZERO-ZERO -----
 func init() {
 	Register(Rule{
-		ID:          "CHAIN-TERMINATOR-ZERO-ZERO",
-		Severity:    SeverityStructural,
-		Description: "each used file's sector chain ends with a (0, 0) link",
-		Citation:    "samdos/src/b.s:104-110",
-		Check:       checkChainTerminatorZeroZero,
+		ID:            "CHAIN-TERMINATOR-ZERO-ZERO",
+		Severity:      SeverityStructural,
+		Description:   "each used file's sector chain ends with a (0, 0) link",
+		Citation:      "samdos/src/b.s:104-110",
+		Check:         checkChainTerminatorZeroZero,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -110,11 +111,12 @@ func checkChainTerminatorZeroZero(ctx *CheckContext) []Finding {
 // ----- CHAIN-NO-CYCLE -----
 func init() {
 	Register(Rule{
-		ID:          "CHAIN-NO-CYCLE",
-		Severity:    SeverityStructural,
-		Description: "each used file's sector chain has no revisited sectors",
-		Citation:    "samfile.go:743-754",
-		Check:       checkChainNoCycle,
+		ID:            "CHAIN-NO-CYCLE",
+		Severity:      SeverityStructural,
+		Description:   "each used file's sector chain has no revisited sectors",
+		Citation:      "samfile.go:743-754",
+		Check:         checkChainNoCycle,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -138,11 +140,12 @@ func checkChainNoCycle(ctx *CheckContext) []Finding {
 // ----- CHAIN-MATCHES-SAM -----
 func init() {
 	Register(Rule{
-		ID:          "CHAIN-MATCHES-SAM",
-		Severity:    SeverityInconsistency,
-		Description: "the set of sectors walked by the chain equals the bits set in the SectorAddressMap",
-		Citation:    "samdos/src/c.s:1306-1343",
-		Check:       checkChainMatchesSAM,
+		ID:            "CHAIN-MATCHES-SAM",
+		Severity:      SeverityInconsistency,
+		Description:   "the set of sectors walked by the chain equals the bits set in the SectorAddressMap",
+		Citation:      "samdos/src/c.s:1306-1343",
+		Check:         checkChainMatchesSAM,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -190,11 +193,12 @@ func checkChainMatchesSAM(ctx *CheckContext) []Finding {
 // ----- CHAIN-SECTOR-COUNT-MINIMAL -----
 func init() {
 	Register(Rule{
-		ID:          "CHAIN-SECTOR-COUNT-MINIMAL",
-		Severity:    SeverityCosmetic,
-		Description: "used file occupies exactly ceil((9 + body length) / 510) sectors (no padding sectors)",
-		Citation:    "samfile.go:919",
-		Check:       checkChainSectorCountMinimal,
+		ID:            "CHAIN-SECTOR-COUNT-MINIMAL",
+		Severity:      SeverityCosmetic,
+		Description:   "used file occupies exactly ceil((9 + body length) / 510) sectors (no padding sectors)",
+		Citation:      "samfile.go:919",
+		Check:         checkChainSectorCountMinimal,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 

--- a/rules_cosmetic.go
+++ b/rules_cosmetic.go
@@ -20,11 +20,12 @@ import "fmt"
 // real-ROM-SAVE byte == 0xFF, samfile byte == 0x00, both legitimate.
 func init() {
 	Register(Rule{
-		ID:          "COSMETIC-RESERVEDA-FF",
-		Severity:    SeverityCosmetic,
-		Description: "ReservedA (dir 0xE8-0xEB) is uniformly 0x00 (samfile) or 0xFF (ROM SAMDOS-2)",
-		Citation:    "rom-disasm:22076-22080",
-		Check:       checkCosmeticReservedAFF,
+		ID:            "COSMETIC-RESERVEDA-FF",
+		Severity:      SeverityCosmetic,
+		Description:   "ReservedA (dir 0xE8-0xEB) is uniformly 0x00 (samfile) or 0xFF (ROM SAMDOS-2)",
+		Citation:      "rom-disasm:22076-22080",
+		Check:         checkCosmeticReservedAFF,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 

--- a/rules_cross.go
+++ b/rules_cross.go
@@ -13,11 +13,12 @@ import (
 // ----- CROSS-NO-SECTOR-OVERLAP -----
 func init() {
 	Register(Rule{
-		ID:          "CROSS-NO-SECTOR-OVERLAP",
-		Severity:    SeverityInconsistency,
-		Description: "no two used files claim the same data sector",
-		Citation:    "samdos/src/c.s:895-951",
-		Check:       checkCrossNoSectorOverlap,
+		ID:            "CROSS-NO-SECTOR-OVERLAP",
+		Severity:      SeverityInconsistency,
+		Description:   "no two used files claim the same data sector",
+		Citation:      "samdos/src/c.s:895-951",
+		Check:         checkCrossNoSectorOverlap,
+		Applicability: &RuleApplicability{Scope: DiskScope},
 	})
 }
 
@@ -55,11 +56,12 @@ func checkCrossNoSectorOverlap(ctx *CheckContext) []Finding {
 // ----- CROSS-NO-DUPLICATE-NAMES -----
 func init() {
 	Register(Rule{
-		ID:          "CROSS-NO-DUPLICATE-NAMES",
-		Severity:    SeverityInconsistency,
-		Description: "no two used directory entries share the same filename (case-insensitive)",
-		Citation:    "samdos/src/c.s:1196-1219",
-		Check:       checkCrossNoDuplicateNames,
+		ID:            "CROSS-NO-DUPLICATE-NAMES",
+		Severity:      SeverityInconsistency,
+		Description:   "no two used directory entries share the same filename (case-insensitive)",
+		Citation:      "samdos/src/c.s:1196-1219",
+		Check:         checkCrossNoDuplicateNames,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -89,11 +91,12 @@ func checkCrossNoDuplicateNames(ctx *CheckContext) []Finding {
 // ----- CROSS-DIRECTORY-AREA-UNUSED -----
 func init() {
 	Register(Rule{
-		ID:          "CROSS-DIRECTORY-AREA-UNUSED",
-		Severity:    SeverityStructural,
-		Description: "no chain link in any used file references a directory-area sector (tracks 0-3 of side 0)",
-		Citation:    "samfile.go:984-987",
-		Check:       checkCrossDirectoryAreaUnused,
+		ID:            "CROSS-DIRECTORY-AREA-UNUSED",
+		Severity:      SeverityStructural,
+		Description:   "no chain link in any used file references a directory-area sector (tracks 0-3 of side 0)",
+		Citation:      "samfile.go:984-987",
+		Check:         checkCrossDirectoryAreaUnused,
+		Applicability: &RuleApplicability{Scope: DiskScope},
 	})
 }
 

--- a/rules_directory.go
+++ b/rules_directory.go
@@ -23,11 +23,12 @@ func forEachUsedSlot(ctx *CheckContext, fn func(slot int, fe *FileEntry)) {
 // ----- DIR-TYPE-BYTE-IS-KNOWN -----
 func init() {
 	Register(Rule{
-		ID:          "DIR-TYPE-BYTE-IS-KNOWN",
-		Severity:    SeverityInconsistency,
-		Description: "directory type byte (low 5 bits, attribute bits masked) is one of the documented file types",
-		Citation:    "samdos/src/e.s:322-355",
-		Check:       checkDirTypeByteIsKnown,
+		ID:            "DIR-TYPE-BYTE-IS-KNOWN",
+		Severity:      SeverityInconsistency,
+		Description:   "directory type byte (low 5 bits, attribute bits masked) is one of the documented file types",
+		Citation:      "samdos/src/e.s:322-355",
+		Check:         checkDirTypeByteIsKnown,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -89,11 +90,12 @@ func checkDirTypeByteIsKnown(ctx *CheckContext) []Finding {
 // recoverable header").
 func init() {
 	Register(Rule{
-		ID:          "DIR-ERASED-IS-ZERO",
-		Severity:    SeverityInconsistency,
-		Description: "a used directory slot has a non-zero type byte",
-		Citation:    "samdos/src/c.s:1133-1143",
-		Check:       checkDirErasedIsZero,
+		ID:            "DIR-ERASED-IS-ZERO",
+		Severity:      SeverityInconsistency,
+		Description:   "a used directory slot has a non-zero type byte",
+		Citation:      "samdos/src/c.s:1133-1143",
+		Check:         checkDirErasedIsZero,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -116,11 +118,12 @@ func checkDirErasedIsZero(ctx *CheckContext) []Finding {
 // ----- DIR-NAME-PADDING -----
 func init() {
 	Register(Rule{
-		ID:          "DIR-NAME-PADDING",
-		Severity:    SeverityCosmetic,
-		Description: "filename bytes are printable ASCII or space-padded",
-		Citation:    "sam-coupe_tech-man_v3-0.txt:4358-4359",
-		Check:       checkDirNamePadding,
+		ID:            "DIR-NAME-PADDING",
+		Severity:      SeverityCosmetic,
+		Description:   "filename bytes are printable ASCII or space-padded",
+		Citation:      "sam-coupe_tech-man_v3-0.txt:4358-4359",
+		Check:         checkDirNamePadding,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -147,11 +150,12 @@ func checkDirNamePadding(ctx *CheckContext) []Finding {
 // ----- DIR-NAME-NOT-EMPTY -----
 func init() {
 	Register(Rule{
-		ID:          "DIR-NAME-NOT-EMPTY",
-		Severity:    SeverityInconsistency,
-		Description: "a used slot has at least one non-space, non-FF character in its 10-byte name",
-		Citation:    "rom-disasm:22093-22105",
-		Check:       checkDirNameNotEmpty,
+		ID:            "DIR-NAME-NOT-EMPTY",
+		Severity:      SeverityInconsistency,
+		Description:   "a used slot has at least one non-space, non-FF character in its 10-byte name",
+		Citation:      "rom-disasm:22093-22105",
+		Check:         checkDirNameNotEmpty,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -181,11 +185,12 @@ func checkDirNameNotEmpty(ctx *CheckContext) []Finding {
 // ----- DIR-FIRST-SECTOR-VALID -----
 func init() {
 	Register(Rule{
-		ID:          "DIR-FIRST-SECTOR-VALID",
-		Severity:    SeverityFatal,
-		Description: "directory entry's FirstSector points at a valid data sector",
-		Citation:    "samfile.go:611-616",
-		Check:       checkDirFirstSectorValid,
+		ID:            "DIR-FIRST-SECTOR-VALID",
+		Severity:      SeverityFatal,
+		Description:   "directory entry's FirstSector points at a valid data sector",
+		Citation:      "samfile.go:611-616",
+		Check:         checkDirFirstSectorValid,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -217,11 +222,12 @@ func checkDirFirstSectorValid(ctx *CheckContext) []Finding {
 // ----- DIR-SECTORS-MATCHES-CHAIN -----
 func init() {
 	Register(Rule{
-		ID:          "DIR-SECTORS-MATCHES-CHAIN",
-		Severity:    SeverityStructural,
-		Description: "dir-entry Sectors count equals the number of sectors visited walking the chain to the (0,0) terminator",
-		Citation:    "samfile.go:743-754",
-		Check:       checkDirSectorsMatchesChain,
+		ID:            "DIR-SECTORS-MATCHES-CHAIN",
+		Severity:      SeverityStructural,
+		Description:   "dir-entry Sectors count equals the number of sectors visited walking the chain to the (0,0) terminator",
+		Citation:      "samfile.go:743-754",
+		Check:         checkDirSectorsMatchesChain,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -246,11 +252,12 @@ func checkDirSectorsMatchesChain(ctx *CheckContext) []Finding {
 // ----- DIR-SECTORS-MATCHES-MAP -----
 func init() {
 	Register(Rule{
-		ID:          "DIR-SECTORS-MATCHES-MAP",
-		Severity:    SeverityStructural,
-		Description: "dir-entry Sectors count equals the popcount of the per-slot SectorAddressMap",
-		Citation:    "sam-coupe_tech-man_v3-0.txt:4405-4414",
-		Check:       checkDirSectorsMatchesMap,
+		ID:            "DIR-SECTORS-MATCHES-MAP",
+		Severity:      SeverityStructural,
+		Description:   "dir-entry Sectors count equals the popcount of the per-slot SectorAddressMap",
+		Citation:      "sam-coupe_tech-man_v3-0.txt:4405-4414",
+		Check:         checkDirSectorsMatchesMap,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -277,11 +284,12 @@ func checkDirSectorsMatchesMap(ctx *CheckContext) []Finding {
 // ----- DIR-SECTORS-NONZERO -----
 func init() {
 	Register(Rule{
-		ID:          "DIR-SECTORS-NONZERO",
-		Severity:    SeverityStructural,
-		Description: "a used dir entry's Sectors count is at least 1",
-		Citation:    "samdos/src/c.s:919-951",
-		Check:       checkDirSectorsNonzero,
+		ID:            "DIR-SECTORS-NONZERO",
+		Severity:      SeverityStructural,
+		Description:   "a used dir entry's Sectors count is at least 1",
+		Citation:      "samdos/src/c.s:919-951",
+		Check:         checkDirSectorsNonzero,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 
@@ -307,11 +315,12 @@ func checkDirSectorsNonzero(ctx *CheckContext) []Finding {
 // (top 3 bits of byte 194), per Tech Manual L4405-4406.
 func init() {
 	Register(Rule{
-		ID:          "DIR-SAM-WITHIN-CAPACITY",
-		Severity:    SeverityInconsistency,
-		Description: "SectorAddressMap byte 194's top 3 bits (1557-1559) are clear (no sector beyond disk capacity)",
-		Citation:    "sam-coupe_tech-man_v3-0.txt:4405-4406",
-		Check:       checkDirSAMWithinCapacity,
+		ID:            "DIR-SAM-WITHIN-CAPACITY",
+		Severity:      SeverityInconsistency,
+		Description:   "SectorAddressMap byte 194's top 3 bits (1557-1559) are clear (no sector beyond disk capacity)",
+		Citation:      "sam-coupe_tech-man_v3-0.txt:4405-4406",
+		Check:         checkDirSAMWithinCapacity,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: usedSlot},
 	})
 }
 

--- a/rules_disk.go
+++ b/rules_disk.go
@@ -65,11 +65,12 @@ func trackSectorRefs(ctx *CheckContext) []sectorRef {
 
 func init() {
 	Register(Rule{
-		ID:          "DISK-DIRECTORY-TRACKS",
-		Severity:    SeverityStructural,
-		Description: "no file references a sector in the directory area (tracks 0-3 of side 0)",
-		Citation:    "sam-coupe_tech-man_v3-0.txt:4340-4343",
-		Check:       checkDiskDirectoryTracks,
+		ID:            "DISK-DIRECTORY-TRACKS",
+		Severity:      SeverityStructural,
+		Description:   "no file references a sector in the directory area (tracks 0-3 of side 0)",
+		Citation:      "sam-coupe_tech-man_v3-0.txt:4340-4343",
+		Check:         checkDiskDirectoryTracks,
+		Applicability: &RuleApplicability{Scope: DiskScope},
 	})
 }
 
@@ -97,11 +98,12 @@ func checkDiskDirectoryTracks(ctx *CheckContext) []Finding {
 
 func init() {
 	Register(Rule{
-		ID:          "DISK-TRACK-SIDE-ENCODING",
-		Severity:    SeverityFatal,
-		Description: "every track byte references a physical cylinder 0-79 on side 0 or side 1",
-		Citation:    "samfile.go:393-394",
-		Check:       checkDiskTrackSideEncoding,
+		ID:            "DISK-TRACK-SIDE-ENCODING",
+		Severity:      SeverityFatal,
+		Description:   "every track byte references a physical cylinder 0-79 on side 0 or side 1",
+		Citation:      "samfile.go:393-394",
+		Check:         checkDiskTrackSideEncoding,
+		Applicability: &RuleApplicability{Scope: DiskScope},
 	})
 }
 
@@ -130,11 +132,12 @@ func checkDiskTrackSideEncoding(ctx *CheckContext) []Finding {
 
 func init() {
 	Register(Rule{
-		ID:          "DISK-SECTOR-RANGE",
-		Severity:    SeverityFatal,
-		Description: "every sector number is in range 1-10 (or 0 for the chain terminator)",
-		Citation:    "samfile.go:389-392",
-		Check:       checkDiskSectorRange,
+		ID:            "DISK-SECTOR-RANGE",
+		Severity:      SeverityFatal,
+		Description:   "every sector number is in range 1-10 (or 0 for the chain terminator)",
+		Citation:      "samfile.go:389-392",
+		Check:         checkDiskSectorRange,
+		Applicability: &RuleApplicability{Scope: DiskScope},
 	})
 }
 

--- a/rules_ft_array.go
+++ b/rules_ft_array.go
@@ -12,11 +12,12 @@ package samfile
 // writer didn't populate the array metadata at SAVE time.
 func init() {
 	Register(Rule{
-		ID:          "ARRAY-FILETYPEINFO-TLBYTE-NAME",
-		Severity:    SeverityStructural,
-		Description: "FT_NUM_ARRAY/FT_STR_ARRAY FileTypeInfo (dir 0xDD-0xE7) is not all zero",
-		Citation:    "rom-disasm:22354-22357",
-		Check:       checkArrayFileTypeInfoTLBYTEName,
+		ID:            "ARRAY-FILETYPEINFO-TLBYTE-NAME",
+		Severity:      SeverityStructural,
+		Description:   "FT_NUM_ARRAY/FT_STR_ARRAY FileTypeInfo (dir 0xDD-0xE7) is not all zero",
+		Citation:      "rom-disasm:22354-22357",
+		Check:         checkArrayFileTypeInfoTLBYTEName,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_NUM_ARRAY, FT_STR_ARRAY)},
 	})
 }
 

--- a/rules_ft_basic.go
+++ b/rules_ft_basic.go
@@ -55,11 +55,12 @@ func bodyData(di *DiskImage, fe *FileEntry) ([]byte, error) {
 // NVARS <= NUMEND <= SAVARS <= body Length.
 func init() {
 	Register(Rule{
-		ID:          "BASIC-FILETYPEINFO-TRIPLETS",
-		Severity:    SeverityStructural,
-		Description: "FT_SAM_BASIC FileTypeInfo (dir 0xDD-0xE5) holds three non-zero, non-decreasing PAGEFORM cumulative offsets bounded by body length",
-		Citation:    "rom-disasm:22163-22180",
-		Check:       checkBasicFileTypeInfoTriplets,
+		ID:            "BASIC-FILETYPEINFO-TRIPLETS",
+		Severity:      SeverityStructural,
+		Description:   "FT_SAM_BASIC FileTypeInfo (dir 0xDD-0xE5) holds three non-zero, non-decreasing PAGEFORM cumulative offsets bounded by body length",
+		Citation:      "rom-disasm:22163-22180",
+		Check:         checkBasicFileTypeInfoTriplets,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_SAM_BASIC)},
 	})
 }
 
@@ -101,11 +102,12 @@ func checkBasicFileTypeInfoTriplets(ctx *CheckContext) []Finding {
 // accept either value.
 func init() {
 	Register(Rule{
-		ID:          "BASIC-VARS-GAP-INVARIANT",
-		Severity:    SeverityCosmetic,
-		Description: "FT_SAM_BASIC SAVARS-NVARS equals the dialect-canonical value (604 SAMDOS-2 / 2156 MasterDOS)",
-		Citation:    "sam-basic-save-format.md",
-		Check:       checkBasicVarsGapInvariant,
+		ID:            "BASIC-VARS-GAP-INVARIANT",
+		Severity:      SeverityCosmetic,
+		Description:   "FT_SAM_BASIC SAVARS-NVARS equals the dialect-canonical value (604 SAMDOS-2 / 2156 MasterDOS)",
+		Citation:      "sam-basic-save-format.md",
+		Check:         checkBasicVarsGapInvariant,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_SAM_BASIC)},
 	})
 }
 
@@ -147,11 +149,12 @@ func checkBasicVarsGapInvariant(ctx *CheckContext) []Finding {
 // end offset).
 func init() {
 	Register(Rule{
-		ID:          "BASIC-PROG-END-SENTINEL",
-		Severity:    SeverityStructural,
-		Description: "FT_SAM_BASIC program-area ends with a 0xFF sentinel byte",
-		Citation:    "sambasic/file.go:36-42",
-		Check:       checkBasicProgEndSentinel,
+		ID:            "BASIC-PROG-END-SENTINEL",
+		Severity:      SeverityStructural,
+		Description:   "FT_SAM_BASIC program-area ends with a 0xFF sentinel byte",
+		Citation:      "sambasic/file.go:36-42",
+		Check:         checkBasicProgEndSentinel,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_SAM_BASIC)},
 	})
 }
 
@@ -200,11 +203,12 @@ func checkBasicProgEndSentinel(ctx *CheckContext) []Finding {
 // the type; only the `== 0` check remains as an explicit guard.
 func init() {
 	Register(Rule{
-		ID:          "BASIC-LINE-NUMBER-BE",
-		Severity:    SeverityStructural,
-		Description: "FT_SAM_BASIC program parses cleanly and every line number is in 1..65535 (uint16 BE; widened from 1..16383 in iteration 1)",
-		Citation:    "sambasic/parse.go",
-		Check:       checkBasicLineNumberBE,
+		ID:            "BASIC-LINE-NUMBER-BE",
+		Severity:      SeverityStructural,
+		Description:   "FT_SAM_BASIC program parses cleanly and every line number is in 1..65535 (uint16 BE; widened from 1..16383 in iteration 1)",
+		Citation:      "sambasic/parse.go",
+		Check:         checkBasicLineNumberBE,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_SAM_BASIC)},
 	})
 }
 
@@ -256,11 +260,12 @@ func checkBasicLineNumberBE(ctx *CheckContext) []Finding {
 // a valid line number (1..16383, not 0xFFFF).
 func init() {
 	Register(Rule{
-		ID:          "BASIC-STARTLINE-FF-DISABLES",
-		Severity:    SeverityStructural,
-		Description: "FT_SAM_BASIC dir[0xF2] is 0x00 (auto-RUN) or 0xFF (no auto-RUN); when 0x00, the start-line is a valid line number",
-		Citation:    "rom-disasm:22136-22141",
-		Check:       checkBasicStartLineFFDisables,
+		ID:            "BASIC-STARTLINE-FF-DISABLES",
+		Severity:      SeverityStructural,
+		Description:   "FT_SAM_BASIC dir[0xF2] is 0x00 (auto-RUN) or 0xFF (no auto-RUN); when 0x00, the start-line is a valid line number",
+		Citation:      "rom-disasm:22136-22141",
+		Check:         checkBasicStartLineFFDisables,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_SAM_BASIC)},
 	})
 }
 
@@ -321,11 +326,12 @@ func checkBasicStartLineFFDisables(ctx *CheckContext) []Finding {
 // Severity stays cosmetic.
 func init() {
 	Register(Rule{
-		ID:          "BASIC-STARTLINE-WITHIN-PROG",
-		Severity:    SeverityCosmetic,
-		Description: "FT_SAM_BASIC auto-RUN start-line is at or below the highest saved line (RUN's NEXT-LINE-GE lookup tolerates start-lines below the lowest saved line)",
-		Citation:    "rom-disasm:22136-22141",
-		Check:       checkBasicStartLineWithinProg,
+		ID:            "BASIC-STARTLINE-WITHIN-PROG",
+		Severity:      SeverityCosmetic,
+		Description:   "FT_SAM_BASIC auto-RUN start-line is at or below the highest saved line (RUN's NEXT-LINE-GE lookup tolerates start-lines below the lowest saved line)",
+		Citation:      "rom-disasm:22136-22141",
+		Check:         checkBasicStartLineWithinProg,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_SAM_BASIC)},
 	})
 }
 
@@ -383,11 +389,12 @@ func checkBasicStartLineWithinProg(ctx *CheckContext) []Finding {
 // test-mgt-byte-layout.md §slot 1). Inconsistency severity.
 func init() {
 	Register(Rule{
-		ID:          "BASIC-MGTFLAGS-20",
-		Severity:    SeverityInconsistency,
-		Description: "FT_SAM_BASIC MGTFlags is 0x20 (empirical convention)",
-		Citation:    "test-mgt-byte-layout.md",
-		Check:       checkBasicMGTFlags20,
+		ID:            "BASIC-MGTFLAGS-20",
+		Severity:      SeverityInconsistency,
+		Description:   "FT_SAM_BASIC MGTFlags is 0x20 (empirical convention)",
+		Citation:      "test-mgt-byte-layout.md",
+		Check:         checkBasicMGTFlags20,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_SAM_BASIC)},
 	})
 }
 

--- a/rules_ft_code.go
+++ b/rules_ft_code.go
@@ -12,11 +12,12 @@ import "fmt"
 // ----- CODE-LOAD-ABOVE-ROM -----
 func init() {
 	Register(Rule{
-		ID:          "CODE-LOAD-ABOVE-ROM",
-		Severity:    SeverityFatal,
-		Description: "FT_CODE file's load address is at least 0x4000 (above ROM)",
-		Citation:    "samfile.go:799-801",
-		Check:       checkCodeLoadAboveROM,
+		ID:            "CODE-LOAD-ABOVE-ROM",
+		Severity:      SeverityFatal,
+		Description:   "FT_CODE file's load address is at least 0x4000 (above ROM)",
+		Citation:      "samfile.go:799-801",
+		Check:         checkCodeLoadAboveROM,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_CODE)},
 	})
 }
 
@@ -43,11 +44,12 @@ func checkCodeLoadAboveROM(ctx *CheckContext) []Finding {
 // ----- CODE-LOAD-FITS-IN-MEMORY -----
 func init() {
 	Register(Rule{
-		ID:          "CODE-LOAD-FITS-IN-MEMORY",
-		Severity:    SeverityFatal,
-		Description: "FT_CODE file's load address + body length does not exceed SAM's 512 KiB address space",
-		Citation:    "samfile.go:802-804",
-		Check:       checkCodeLoadFitsInMemory,
+		ID:            "CODE-LOAD-FITS-IN-MEMORY",
+		Severity:      SeverityFatal,
+		Description:   "FT_CODE file's load address + body length does not exceed SAM's 512 KiB address space",
+		Citation:      "samfile.go:802-804",
+		Check:         checkCodeLoadFitsInMemory,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_CODE)},
 	})
 }
 
@@ -76,11 +78,12 @@ func checkCodeLoadFitsInMemory(ctx *CheckContext) []Finding {
 // ----- CODE-EXEC-WITHIN-LOADED-RANGE -----
 func init() {
 	Register(Rule{
-		ID:          "CODE-EXEC-WITHIN-LOADED-RANGE",
-		Severity:    SeverityStructural,
-		Description: "FT_CODE file's execution address (when not 0xFF-disabled) lies within its loaded region",
-		Citation:    "samfile.go:805-810",
-		Check:       checkCodeExecWithinLoadedRange,
+		ID:            "CODE-EXEC-WITHIN-LOADED-RANGE",
+		Severity:      SeverityStructural,
+		Description:   "FT_CODE file's execution address (when not 0xFF-disabled) lies within its loaded region",
+		Citation:      "samfile.go:805-810",
+		Check:         checkCodeExecWithinLoadedRange,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_CODE)},
 	})
 }
 
@@ -135,11 +138,12 @@ func checkCodeExecWithinLoadedRange(ctx *CheckContext) []Finding {
 // overwrite.
 func init() {
 	Register(Rule{
-		ID:          "CODE-FILETYPEINFO-EMPTY",
-		Severity:    SeverityCosmetic,
-		Description: "FT_CODE file's FileTypeInfo (dir 0xDD-0xE7) is uniformly 0x00 (samfile), 0xFF (ROM SAMDOS-2), or 0x20 (HDR space-fill leakage) — unused-marker convention",
-		Citation:    "samfile.go:798-827",
-		Check:       checkCodeFileTypeInfoEmpty,
+		ID:            "CODE-FILETYPEINFO-EMPTY",
+		Severity:      SeverityCosmetic,
+		Description:   "FT_CODE file's FileTypeInfo (dir 0xDD-0xE7) is uniformly 0x00 (samfile), 0xFF (ROM SAMDOS-2), or 0x20 (HDR space-fill leakage) — unused-marker convention",
+		Citation:      "samfile.go:798-827",
+		Check:         checkCodeFileTypeInfoEmpty,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_CODE)},
 	})
 }
 

--- a/rules_ft_screen.go
+++ b/rules_ft_screen.go
@@ -12,11 +12,12 @@ import "fmt"
 // (1-4 on SAM).
 func init() {
 	Register(Rule{
-		ID:          "SCREEN-MODE-AT-0xDD",
-		Severity:    SeverityStructural,
-		Description: "FT_SCREEN dir[0xDD] (mode byte) is in 1..4",
-		Citation:    "rom-disasm:22259",
-		Check:       checkScreenModeAt0xDD,
+		ID:            "SCREEN-MODE-AT-0xDD",
+		Severity:      SeverityStructural,
+		Description:   "FT_SCREEN dir[0xDD] (mode byte) is in 1..4",
+		Citation:      "rom-disasm:22259",
+		Check:         checkScreenModeAt0xDD,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_SCREEN)},
 	})
 }
 
@@ -58,11 +59,12 @@ func checkScreenModeAt0xDD(ctx *CheckContext) []Finding {
 // dir byte but mode-3-sized body).
 func init() {
 	Register(Rule{
-		ID:          "SCREEN-LENGTH-MATCHES-MODE",
-		Severity:    SeverityStructural,
-		Description: "FT_SCREEN body length is within [min, min+512] for its mode (1-2: min=6912; 3-4: min=24576) — slack accommodates the ROM SCREEN$ SAVE palette+sysvars trailer",
-		Citation:    "sam-coupe_tech-man_v3-0.txt",
-		Check:       checkScreenLengthMatchesMode,
+		ID:            "SCREEN-LENGTH-MATCHES-MODE",
+		Severity:      SeverityStructural,
+		Description:   "FT_SCREEN body length is within [min, min+512] for its mode (1-2: min=6912; 3-4: min=24576) — slack accommodates the ROM SCREEN$ SAVE palette+sysvars trailer",
+		Citation:      "sam-coupe_tech-man_v3-0.txt",
+		Check:         checkScreenLengthMatchesMode,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_SCREEN)},
 	})
 }
 

--- a/rules_ft_zxsnap.go
+++ b/rules_ft_zxsnap.go
@@ -14,11 +14,12 @@ import "fmt"
 // FT_ZX_SNAPSHOT has a 49,152-byte body (48 KiB ZX RAM).
 func init() {
 	Register(Rule{
-		ID:          "ZXSNAP-LENGTH-49152",
-		Severity:    SeverityStructural,
-		Description: "FT_ZX_SNAPSHOT body is exactly 49152 bytes (48 KiB ZX RAM)",
-		Citation:    "samdos/src/d.s:660-661",
-		Check:       checkZXSnapLength49152,
+		ID:            "ZXSNAP-LENGTH-49152",
+		Severity:      SeverityStructural,
+		Description:   "FT_ZX_SNAPSHOT body is exactly 49152 bytes (48 KiB ZX RAM)",
+		Citation:      "samdos/src/d.s:660-661",
+		Check:         checkZXSnapLength49152,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_ZX_SNAPSHOT)},
 	})
 }
 
@@ -44,11 +45,12 @@ func checkZXSnapLength49152(ctx *CheckContext) []Finding {
 // FT_ZX_SNAPSHOT load address is 0x4000 (ZX RAM base).
 func init() {
 	Register(Rule{
-		ID:          "ZXSNAP-LOAD-ADDR-16384",
-		Severity:    SeverityStructural,
-		Description: "FT_ZX_SNAPSHOT decoded start address is 0x4000 (16384, ZX RAM base)",
-		Citation:    "samdos/src/d.s:660-663",
-		Check:       checkZXSnapLoadAddr16384,
+		ID:            "ZXSNAP-LOAD-ADDR-16384",
+		Severity:      SeverityStructural,
+		Description:   "FT_ZX_SNAPSHOT decoded start address is 0x4000 (16384, ZX RAM base)",
+		Citation:      "samdos/src/d.s:660-663",
+		Check:         checkZXSnapLoadAddr16384,
+		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_ZX_SNAPSHOT)},
 	})
 }
 

--- a/rules_ft_zxsnap.go
+++ b/rules_ft_zxsnap.go
@@ -4,11 +4,18 @@ package samfile
 import "fmt"
 
 // §10 ZX snapshot rules (catalog docs/disk-validity-rules.md §10).
-// Rules in this file check FT_ZX_SNAPSHOT (5) invariants: 48 KiB
-// body length and 0x4000 load address. The catalog tags these as
-// SAMDOS-2 specific (the constants live in SAMDOS source); we run
-// them on all dialects because the ZX snapshot format is itself
-// dialect-agnostic.
+// Rules in this file check FT_ZX_SNAPSHOT (5) invariants per
+// SAMDOS-2's snapshot save convention: 49152-byte body and 0x4000
+// load address (samdos/src/d.s:629-630, :612 → :662).
+//
+// Scoped to DialectSAMDOS2: corpus data (audit run 2026-05-12)
+// showed both rules failing 192/193 times across 25 disks. Of those
+// 25, 22 are masterdos-dialect and 3 unknown-dialect; zero are
+// samdos2. The masterdos ZX-snapshot entries are typically +D /
+// Disciple-format imports that use a different Pages/PageOffset
+// encoding — decoded Length/Start don't match 49152/0x4000 but the
+// files are still loadable via their original-OS loader. The rules
+// are correct for SAMDOS-2 but over-strict elsewhere.
 
 // ----- ZXSNAP-LENGTH-49152 -----
 // FT_ZX_SNAPSHOT has a 49,152-byte body (48 KiB ZX RAM).
@@ -16,7 +23,8 @@ func init() {
 	Register(Rule{
 		ID:            "ZXSNAP-LENGTH-49152",
 		Severity:      SeverityStructural,
-		Description:   "FT_ZX_SNAPSHOT body is exactly 49152 bytes (48 KiB ZX RAM)",
+		Dialects:      []Dialect{DialectSAMDOS2},
+		Description:   "FT_ZX_SNAPSHOT body is exactly 49152 bytes (48 KiB ZX RAM); SAMDOS-2 only",
 		Citation:      "samdos/src/d.s:660-661",
 		Check:         checkZXSnapLength49152,
 		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_ZX_SNAPSHOT)},
@@ -47,7 +55,8 @@ func init() {
 	Register(Rule{
 		ID:            "ZXSNAP-LOAD-ADDR-16384",
 		Severity:      SeverityStructural,
-		Description:   "FT_ZX_SNAPSHOT decoded start address is 0x4000 (16384, ZX RAM base)",
+		Dialects:      []Dialect{DialectSAMDOS2},
+		Description:   "FT_ZX_SNAPSHOT decoded start address is 0x4000 (16384, ZX RAM base); SAMDOS-2 only",
 		Citation:      "samdos/src/d.s:660-663",
 		Check:         checkZXSnapLoadAddr16384,
 		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_ZX_SNAPSHOT)},

--- a/rules_smoke.go
+++ b/rules_smoke.go
@@ -10,12 +10,13 @@ import "fmt"
 // but technically valid SAM-format output.
 func init() {
 	Register(Rule{
-		ID:          "DISK-NOT-EMPTY",
-		Severity:    SeverityInconsistency,
-		Dialects:    nil, // all dialects
-		Description: "disk has at least one occupied directory entry",
-		Citation:    "docs/disk-validity-rules.md",
-		Check:       checkDiskNotEmpty,
+		ID:            "DISK-NOT-EMPTY",
+		Severity:      SeverityInconsistency,
+		Dialects:      nil, // all dialects
+		Description:   "disk has at least one occupied directory entry",
+		Citation:      "docs/disk-validity-rules.md",
+		Check:         checkDiskNotEmpty,
+		Applicability: &RuleApplicability{Scope: DiskScope},
 	})
 }
 

--- a/subject.go
+++ b/subject.go
@@ -1,0 +1,31 @@
+package samfile
+
+// SubjectScope identifies the kind of subject a Rule operates on.
+type SubjectScope int
+
+const (
+	DiskScope SubjectScope = iota
+	SlotScope
+	ChainStepScope
+)
+
+func (s SubjectScope) String() string {
+	switch s {
+	case DiskScope:
+		return "disk"
+	case SlotScope:
+		return "slot"
+	case ChainStepScope:
+		return "chain_step"
+	}
+	return "unknown"
+}
+
+// Subject is the universal interface for anything a rule can check —
+// a whole disk, a directory slot, or a single sector in a file's
+// chain. Ref() returns a stable string id; Attributes() returns the
+// denormalised attribute snapshot recorded with every Check event.
+type Subject interface {
+	Ref() string
+	Attributes() map[string]any
+}

--- a/subject_chain.go
+++ b/subject_chain.go
@@ -1,0 +1,56 @@
+package samfile
+
+import "fmt"
+
+// ChainStepSubject wraps one step in a file's sector chain. Track
+// and Sector identify the sector itself; ChainIndex is the 0..N-1
+// position within this slot's chain.
+type ChainStepSubject struct {
+	SlotIndex   int
+	ChainIndex  int
+	Track       uint8
+	Sector      uint8
+	NextTrack   uint8
+	NextSector  uint8
+	Position    string // first | intermediate | last | orphan
+	OnSAMMap    bool
+	OnDirSAMMap bool
+	Disk        *DiskImage
+	Journal     *DiskJournal
+}
+
+func (s *ChainStepSubject) Ref() string {
+	return fmt.Sprintf("slot=%d,chain=%d,track=%d,sector=%d", s.SlotIndex, s.ChainIndex, s.Track, s.Sector)
+}
+
+func (s *ChainStepSubject) Attributes() map[string]any {
+	side := 0
+	if s.Track&0x80 != 0 {
+		side = 1
+	}
+	// Distance from dir tracks: dir is tracks 0..3 of side 0.
+	dirDistance := 999
+	t := int(s.Track & 0x7F)
+	if side == 0 {
+		if t >= 4 {
+			dirDistance = t - 3
+		} else {
+			dirDistance = 0
+		}
+	} else {
+		dirDistance = t + 1
+	}
+	return map[string]any{
+		"slot_index":               s.SlotIndex,
+		"chain_index":              s.ChainIndex,
+		"chain_position":           s.Position,
+		"track":                    int(s.Track),
+		"sector":                   int(s.Sector),
+		"side":                     side,
+		"next_track":               int(s.NextTrack),
+		"next_sector":              int(s.NextSector),
+		"on_sam_map":               s.OnSAMMap,
+		"on_dir_sam_map":           s.OnDirSAMMap,
+		"distance_from_dir_tracks": dirDistance,
+	}
+}

--- a/subject_disk.go
+++ b/subject_disk.go
@@ -1,0 +1,33 @@
+package samfile
+
+// DiskSubject wraps a DiskJournal + DiskImage for disk-scope rule
+// evaluation. Single instance per Verify() run.
+type DiskSubject struct {
+	Journal *DiskJournal
+	Disk    *DiskImage
+	Dialect Dialect
+}
+
+func (s *DiskSubject) Ref() string { return "disk" }
+
+func (s *DiskSubject) Attributes() map[string]any {
+	used := len(s.Journal.UsedFileEntries())
+	bootSig := false
+	if sd, err := s.Disk.SectorData(&Sector{Track: 4, Sector: 1}); err == nil {
+		// Match the ROM's masked compare (rom-disasm:20582-20598): bit 5
+		// (case) and bit 7 ignored.
+		expected := [4]byte{'B', 'O', 'O', 'T'}
+		bootSig = true
+		for i := 0; i < 4; i++ {
+			if (sd[256+i]^expected[i])&0x5F != 0 {
+				bootSig = false
+				break
+			}
+		}
+	}
+	return map[string]any{
+		"dialect":                s.Dialect.String(),
+		"boot_signature_present": bootSig,
+		"used_slot_count":        used,
+	}
+}

--- a/subject_slot.go
+++ b/subject_slot.go
@@ -1,0 +1,72 @@
+package samfile
+
+import (
+	"encoding/hex"
+	"fmt"
+)
+
+// SlotSubject wraps one directory slot's FileEntry for slot-scope
+// rule evaluation. SlotIndex is the 0..79 position; FileEntry is
+// the parsed dir entry. For erased slots (Type==0) the FileEntry
+// still exists but most fields are zero.
+type SlotSubject struct {
+	SlotIndex int
+	FileEntry *FileEntry
+	Disk      *DiskImage
+	Journal   *DiskJournal
+}
+
+func (s *SlotSubject) Ref() string { return fmt.Sprintf("slot=%d", s.SlotIndex) }
+
+func (s *SlotSubject) Attributes() map[string]any {
+	fe := s.FileEntry
+	if fe == nil {
+		return map[string]any{
+			"slot_index":     s.SlotIndex,
+			"slot_is_erased": true,
+		}
+	}
+	pageOffsetForm := "other"
+	switch fe.StartAddressPageOffset & 0xC000 {
+	case 0x8000:
+		pageOffsetForm = "0x8000"
+	case 0x4000:
+		pageOffsetForm = "0x4000"
+	case 0x0000:
+		pageOffsetForm = "0x0000"
+	case 0xC000:
+		pageOffsetForm = "0xC000"
+	}
+	dirMirrorPopulated := false
+	for _, b := range fe.MGTFutureAndPast[1:10] {
+		if b != 0 {
+			dirMirrorPopulated = true
+			break
+		}
+	}
+	hasAutoRunOrAutoExec := fe.ExecutionAddressDiv16K != 0xFF
+	ftrack, fsector, fside := 0, 0, 0
+	if fe.FirstSector != nil {
+		ftrack = int(fe.FirstSector.Track)
+		fsector = int(fe.FirstSector.Sector)
+		fside = int(fe.FirstSector.Track >> 7)
+	}
+	return map[string]any{
+		"slot_index":              s.SlotIndex,
+		"filename":                fe.Name.String(),
+		"file_type":               fe.Type.String(),
+		"file_type_byte":          int(fe.Type),
+		"file_length":             int(fe.LengthMod16K),
+		"page_offset_form":        pageOffsetForm,
+		"pages":                   int(fe.Pages),
+		"mgt_flags":               int(fe.MGTFlags),
+		"first_track":             ftrack,
+		"first_sector":            fsector,
+		"first_side":              fside,
+		"has_autorun_or_autoexec": hasAutoRunOrAutoExec,
+		"dir_mirror_populated":    dirMirrorPopulated,
+		"slot_is_erased":          fe.Type == 0,
+		"file_type_info_hex":      hex.EncodeToString(fe.FileTypeInfo[:]),
+		"sectors_count":           int(fe.Sectors),
+	}
+}

--- a/tools/audit/ingest.py
+++ b/tools/audit/ingest.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Ingest JSONL CheckEvents from samfile --format jsonl into the
+`checks` table of ~/sam-corpus/findings.db.
+
+Reads: ~/sam-corpus/outputs-jsonl/<disk>.jsonl
+Writes: ~/sam-corpus/findings.db (creates / replaces `checks` table).
+Existing `disks` and `findings` tables are not touched.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+CORPUS = Path.home() / "sam-corpus"
+JSONL_DIR = CORPUS / "outputs-jsonl"
+DB = CORPUS / "findings.db"
+
+# Column schema for the checks table. Order matters — used to build
+# the INSERT placeholders.
+COLUMNS = [
+    # event header
+    ("disk", "TEXT"),
+    ("rule_id", "TEXT"),
+    ("scope", "TEXT"),
+    ("ref", "TEXT"),
+    ("outcome", "TEXT"),
+    # disk-scope attrs
+    ("dialect", "TEXT"),
+    ("boot_signature_present", "INTEGER"),
+    ("used_slot_count", "INTEGER"),
+    # slot-scope attrs
+    ("slot_index", "INTEGER"),
+    ("filename", "TEXT"),
+    ("file_type", "TEXT"),
+    ("file_type_byte", "INTEGER"),
+    ("file_length", "INTEGER"),
+    ("page_offset_form", "TEXT"),
+    ("pages", "INTEGER"),
+    ("mgt_flags", "INTEGER"),
+    ("first_track", "INTEGER"),
+    ("first_sector", "INTEGER"),
+    ("first_side", "INTEGER"),
+    ("has_autorun_or_autoexec", "INTEGER"),
+    ("dir_mirror_populated", "INTEGER"),
+    ("slot_is_erased", "INTEGER"),
+    ("file_type_info_hex", "TEXT"),
+    ("sectors_count", "INTEGER"),
+    # chain-step attrs (currently unused — reserved)
+    ("chain_position", "TEXT"),
+    ("chain_index", "INTEGER"),
+    ("track", "INTEGER"),
+    ("sector", "INTEGER"),
+    ("side", "INTEGER"),
+    ("next_track", "INTEGER"),
+    ("next_sector", "INTEGER"),
+    ("on_sam_map", "INTEGER"),
+    ("on_dir_sam_map", "INTEGER"),
+    ("distance_from_dir_tracks", "INTEGER"),
+    # finding payload (NULL on pass / not_applicable)
+    ("severity", "TEXT"),
+    ("message", "TEXT"),
+    ("citation", "TEXT"),
+]
+
+COL_NAMES = [c[0] for c in COLUMNS]
+
+
+def column_value(event: dict, col: str):
+    if col in ("disk", "rule_id", "scope", "ref", "outcome"):
+        return event.get(col)
+    attrs = event.get("attrs") or {}
+    if col in attrs:
+        v = attrs[col]
+        if isinstance(v, bool):
+            return int(v)
+        return v
+    finding = event.get("finding") or {}
+    if col == "severity":
+        return finding.get("Severity")
+    if col == "message":
+        return finding.get("Message")
+    if col == "citation":
+        return finding.get("Citation")
+    return None
+
+
+def main() -> None:
+    conn = sqlite3.connect(DB)
+    c = conn.cursor()
+    c.execute("DROP TABLE IF EXISTS checks")
+    c.execute(
+        "CREATE TABLE checks ("
+        + ", ".join(f"{name} {typ}" for name, typ in COLUMNS)
+        + ")"
+    )
+    c.execute("CREATE INDEX idx_checks_rule ON checks(rule_id)")
+    c.execute("CREATE INDEX idx_checks_outcome ON checks(outcome)")
+    c.execute("CREATE INDEX idx_checks_disk ON checks(disk)")
+    c.execute("CREATE INDEX idx_checks_type ON checks(file_type)")
+
+    placeholders = ", ".join("?" for _ in COL_NAMES)
+    insert = f"INSERT INTO checks ({', '.join(COL_NAMES)}) VALUES ({placeholders})"
+
+    n = 0
+    batch = []
+    for path in sorted(JSONL_DIR.glob("*.jsonl")):
+        for line in path.read_text(errors="replace").splitlines():
+            if not line.strip():
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            event.setdefault("disk", path.stem)
+            batch.append(tuple(column_value(event, col) for col in COL_NAMES))
+            n += 1
+            if len(batch) >= 5000:
+                c.executemany(insert, batch)
+                batch = []
+    if batch:
+        c.executemany(insert, batch)
+    conn.commit()
+    print(f"ingested {n} CheckEvents into {DB}")
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/audit/mine.py
+++ b/tools/audit/mine.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Generate audit reports from ~/sam-corpus/findings.db's `checks`
+table.
+
+Reports written under ~/sam-corpus/analyses/. Produced in fail-safe
+order — coverage.md and disk-health.md (the fallback floor) come
+first as plain pandas counts and never fail; the richer reports are
+best-effort with graceful degradation.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import traceback
+from pathlib import Path
+
+import pandas as pd
+
+CORPUS = Path.home() / "sam-corpus"
+DB = CORPUS / "findings.db"
+OUT = CORPUS / "analyses"
+
+
+def load_checks() -> pd.DataFrame:
+    conn = sqlite3.connect(DB)
+    df = pd.read_sql_query("SELECT * FROM checks", conn)
+    conn.close()
+    return df
+
+
+def report_coverage(checks: pd.DataFrame) -> None:
+    """Per-rule applies/fails/fail-rate. The denominator-gap fix."""
+    rows = []
+    for rule_id, grp in checks.groupby("rule_id"):
+        applicable = grp[grp["outcome"].isin(["pass", "fail"])]
+        fails = grp[grp["outcome"] == "fail"]
+        applies_n = len(applicable)
+        fails_n = len(fails)
+        passes_n = (grp["outcome"] == "pass").sum()
+        na_n = (grp["outcome"] == "not_applicable").sum()
+        disks = grp.loc[grp["outcome"] == "fail", "disk"].nunique()
+        rate = (100.0 * fails_n / applies_n) if applies_n else float("nan")
+        sev = fails["severity"].mode().iloc[0] if not fails.empty else ""
+        scope = grp["scope"].mode().iloc[0] if not grp.empty else ""
+        rows.append({
+            "rule_id": rule_id,
+            "severity": sev,
+            "scope": scope,
+            "applies": applies_n,
+            "passes": passes_n,
+            "fails": fails_n,
+            "not_applicable": na_n,
+            "fail_rate_pct": rate,
+            "disks_affected": disks,
+        })
+    df = pd.DataFrame(rows).sort_values(
+        ["fail_rate_pct", "fails"], ascending=[False, False], na_position="last"
+    )
+    md = [
+        "# Per-rule coverage and failure rate",
+        "",
+        "Sorted by fail-rate (descending). `applies` = (pass + fail). `not_applicable` = subjects the rule deliberately skips.",
+        "",
+        "Rules where `scope == legacy` lack denominator metadata — only their fails are recorded; pass-rate is NaN.",
+        "",
+        "| Rule | Severity | Scope | Applies | Passes | Fails | N/A | Fail-rate | Disks |",
+        "|---|---|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for _, r in df.iterrows():
+        rate = "N/A" if pd.isna(r.fail_rate_pct) else f"{r.fail_rate_pct:.1f}%"
+        md.append(
+            f"| `{r.rule_id}` | {r.severity} | {r.scope} | {r.applies} | {r.passes} | {r.fails} | {r.not_applicable} | {rate} | {r.disks_affected} |"
+        )
+    (OUT / "coverage.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'coverage.md'} ({len(df)} rules)")
+
+
+def report_disk_health(checks: pd.DataFrame) -> None:
+    """Per-disk findings + structural-pass score."""
+    rows = []
+    for disk, grp in checks.groupby("disk"):
+        fails = grp[grp["outcome"] == "fail"]
+        total_findings = len(fails)
+        fatal = (fails["severity"] == "fatal").sum()
+        structural = (fails["severity"] == "structural").sum()
+        # Pass rate over checks where the rule fired with structural/fatal anywhere.
+        # Use the rule's modal severity from the corpus to bucket.
+        rule_severity = (
+            checks[checks["outcome"] == "fail"]
+            .groupby("rule_id")["severity"].agg(lambda x: x.mode().iloc[0] if not x.mode().empty else "")
+        ).to_dict()
+        grp_with_sev = grp.copy()
+        grp_with_sev["rule_severity"] = grp_with_sev["rule_id"].map(rule_severity).fillna("")
+        struct = grp_with_sev[
+            grp_with_sev["rule_severity"].isin(["structural", "fatal"]) &
+            grp_with_sev["outcome"].isin(["pass", "fail"])
+        ]
+        sp = (struct["outcome"] == "pass").sum()
+        sf = (struct["outcome"] == "fail").sum()
+        struct_rate = sp / (sp + sf) if (sp + sf) else 1.0
+        distinct_rules_fired = fails["rule_id"].nunique()
+        dialect = grp["dialect"].dropna().mode().iloc[0] if not grp["dialect"].dropna().empty else ""
+        rows.append({
+            "disk": disk,
+            "dialect": dialect,
+            "total_findings": total_findings,
+            "fatal": int(fatal),
+            "structural": int(structural),
+            "structural_pass_rate": struct_rate,
+            "distinct_rules_fired": distinct_rules_fired,
+        })
+    df = pd.DataFrame(rows).sort_values(
+        ["structural_pass_rate", "total_findings"], ascending=[True, False]
+    )
+    md = [
+        "# Per-disk health",
+        "",
+        "Sorted by structural-pass-rate (ascending — worst first). Disks at the top with very low pass-rate and many distinct rules fired are candidate 'not really a disk' specimens that probably shouldn't dilute per-rule pattern analysis.",
+        "",
+        "| Disk | Dialect | Total findings | Fatal | Structural | Struct pass-rate | Distinct rules fired |",
+        "|---|---|---:|---:|---:|---:|---:|",
+    ]
+    for _, r in df.iterrows():
+        md.append(
+            f"| {r.disk[:60]} | {r.dialect} | {r.total_findings} | {r.fatal} | {r.structural} | {r.structural_pass_rate:.2f} | {r.distinct_rules_fired} |"
+        )
+    (OUT / "disk-health.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'disk-health.md'} ({len(df)} disks)")
+
+
+# Attribute columns considered for conditional / decision-tree analyses.
+ATTR_COLS = [
+    "dialect", "boot_signature_present", "used_slot_count",
+    "file_type", "page_offset_form", "first_track", "first_sector",
+    "first_side", "has_autorun_or_autoexec", "dir_mirror_populated",
+    "slot_is_erased", "sectors_count", "file_length", "mgt_flags",
+    "pages",
+]
+
+
+def report_conditional(checks: pd.DataFrame) -> None:
+    """Per-rule conditional fail-rate per attribute value vs baseline."""
+    rows = []
+    for rule_id, grp in checks.groupby("rule_id"):
+        applicable = grp[grp["outcome"].isin(["pass", "fail"])]
+        if len(applicable) < 10:
+            continue
+        baseline = (applicable["outcome"] == "fail").mean()
+        for col in ATTR_COLS:
+            if col not in applicable.columns or applicable[col].isna().all():
+                continue
+            for val, sub in applicable.groupby(col):
+                if len(sub) < 10:
+                    continue
+                cond = (sub["outcome"] == "fail").mean()
+                support_disks = sub["disk"].nunique()
+                if cond in (0.0, 1.0) or abs(cond - baseline) > 0.3:
+                    rows.append({
+                        "rule_id": rule_id,
+                        "attribute": col,
+                        "value": str(val),
+                        "support": len(sub),
+                        "support_disks": support_disks,
+                        "baseline_fail_rate": baseline,
+                        "conditional_fail_rate": cond,
+                        "delta": cond - baseline,
+                    })
+    df = pd.DataFrame(rows).sort_values(
+        ["rule_id", "conditional_fail_rate"], ascending=[True, False]
+    )
+    md = [
+        "# Conditional failure rates per attribute",
+        "",
+        "Surfaces (rule, attribute, value) combinations where the conditional fail-rate differs substantially from the rule's baseline. |Δ| > 30pp OR conditional rate ∈ {0%, 100%}, support ≥ 10 events.",
+        "",
+        "| Rule | Attribute | Value | Support (events) | Support (disks) | Baseline | Conditional | Δ |",
+        "|---|---|---|---:|---:|---:|---:|---:|",
+    ]
+    for _, r in df.iterrows():
+        md.append(
+            f"| `{r.rule_id}` | {r.attribute} | {r.value} | {r.support} | {r.support_disks} | {r.baseline_fail_rate*100:.1f}% | {r.conditional_fail_rate*100:.1f}% | {r.delta*100:+.1f}pp |"
+        )
+    (OUT / "conditional.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'conditional.md'} ({len(df)} rows)")
+
+
+def report_disk_clusters(checks: pd.DataFrame) -> None:
+    """Hierarchical clustering of disks by rule-fire vector."""
+    from sklearn.cluster import AgglomerativeClustering
+
+    pivot = (
+        checks[checks["outcome"] == "fail"]
+        .pivot_table(index="disk", columns="rule_id", values="ref", aggfunc="count", fill_value=0)
+    )
+    if pivot.empty:
+        (OUT / "disk-clusters.md").write_text("# Disk clusters\n\nNo failure events to cluster.\n")
+        return
+    n_clusters = min(8, max(2, len(pivot) // 100))
+    X = (pivot > 0).astype(int).values
+    cl = AgglomerativeClustering(n_clusters=n_clusters)
+    labels = cl.fit_predict(X)
+    pivot["cluster"] = labels
+    md = ["# Disk clusters by rule-fire pattern", "", f"{len(pivot)} disks partitioned into {n_clusters} clusters."]
+    for cid, grp in pivot.groupby("cluster"):
+        top_rules = (grp.drop(columns="cluster") > 0).sum().sort_values(ascending=False).head(8)
+        md.append("")
+        md.append(f"## Cluster {cid} — {len(grp)} disks")
+        md.append("")
+        md.append("Most-fired rules in this cluster (rule, disks-with-fail, share):")
+        for rule, n in top_rules.items():
+            md.append(f"- `{rule}` — {n}/{len(grp)} disks ({100*n/len(grp):.0f}%)")
+        md.append("")
+        md.append("Example disks:")
+        for disk in list(grp.index)[:5]:
+            md.append(f"- {disk[:60]}")
+    (OUT / "disk-clusters.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'disk-clusters.md'} ({n_clusters} clusters)")
+
+
+def report_patterns(checks: pd.DataFrame) -> None:
+    """Per-rule decision-tree splits."""
+    from sklearn.tree import DecisionTreeClassifier, export_text
+
+    md = [
+        "# Per-rule patterns (decision-tree splits)",
+        "",
+        "For each rule with ≥ 50 applicable checks and both pass + fail outcomes, a depth-4 decision tree is trained on the subject attributes to predict fail vs pass. The tree's splits show which attribute values drive failure.",
+        "",
+    ]
+    feat_cols = [c for c in ATTR_COLS if c in checks.columns]
+    for rule_id, grp in checks.groupby("rule_id"):
+        applicable = grp[grp["outcome"].isin(["pass", "fail"])].copy()
+        if len(applicable) < 50:
+            continue
+        y = (applicable["outcome"] == "fail").astype(int)
+        if y.nunique() < 2:
+            continue
+        X = applicable[feat_cols].copy()
+        for c in X.columns:
+            if X[c].dtype == object:
+                X[c] = X[c].astype("category").cat.codes
+            else:
+                X[c] = pd.to_numeric(X[c], errors="coerce").fillna(-1)
+        try:
+            tree = DecisionTreeClassifier(max_depth=4, min_samples_leaf=10).fit(X, y)
+        except ValueError:
+            continue
+        md.append(f"## `{rule_id}` (applies={len(applicable)}, fail-rate={y.mean()*100:.1f}%)")
+        md.append("")
+        md.append("```")
+        md.append(export_text(tree, feature_names=list(X.columns), max_depth=4).strip())
+        md.append("```")
+        md.append("")
+    (OUT / "patterns.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'patterns.md'}")
+
+
+def main() -> None:
+    OUT.mkdir(parents=True, exist_ok=True)
+    checks = load_checks()
+    print(f"loaded {len(checks)} CheckEvents")
+    # Fallback floor — these must always succeed.
+    report_coverage(checks)
+    report_disk_health(checks)
+    # Richer analyses — best-effort.
+    for fn, name in [
+        (report_conditional, "conditional.md"),
+        (report_disk_clusters, "disk-clusters.md"),
+        (report_patterns, "patterns.md"),
+    ]:
+        try:
+            fn(checks)
+        except Exception:
+            traceback.print_exc()
+            print(f"({name} failed; check above)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/audit/mine.py
+++ b/tools/audit/mine.py
@@ -255,6 +255,58 @@ def report_patterns(checks: pd.DataFrame) -> None:
     print(f"wrote {OUT / 'patterns.md'}")
 
 
+def report_high_confidence(checks: pd.DataFrame) -> None:
+    """Distill conditional fail-rates into the high-confidence action
+    list: every (rule, attribute, value) where conditional fail-rate
+    is 0% or 100% on support ≥ 10 distinct disks. These are the
+    patterns the spec's autonomous fix loop is allowed to act on
+    (after source-grounding)."""
+    rows = []
+    for rule_id, grp in checks.groupby("rule_id"):
+        applicable = grp[grp["outcome"].isin(["pass", "fail"])]
+        if len(applicable) < 10:
+            continue
+        baseline = (applicable["outcome"] == "fail").mean()
+        for col in ATTR_COLS:
+            if col not in applicable.columns or applicable[col].isna().all():
+                continue
+            for val, sub in applicable.groupby(col):
+                support_disks = sub["disk"].nunique()
+                if support_disks < 10:
+                    continue
+                cond = (sub["outcome"] == "fail").mean()
+                if cond not in (0.0, 1.0):
+                    continue
+                rows.append({
+                    "rule_id": rule_id,
+                    "attribute": col,
+                    "value": str(val),
+                    "support_events": len(sub),
+                    "support_disks": support_disks,
+                    "conditional_fail_rate": cond,
+                    "baseline_fail_rate": baseline,
+                })
+    df = pd.DataFrame(rows).sort_values(
+        ["conditional_fail_rate", "support_disks"], ascending=[False, False]
+    )
+    md = [
+        "# High-confidence patterns (act-on candidates)",
+        "",
+        "Each row is a (rule, attribute, value) slice where the conditional fail-rate is 0% or 100% on support ≥ 10 distinct disks. These meet the statistical half of the spec's act-on threshold; before acting on any one, ground it in source code (samdos / ROM disasm / samfile) per the design spec.",
+        "",
+        "| Rule | Attribute | Value | Conditional fail-rate | Baseline | Support (disks) | Support (events) |",
+        "|---|---|---|---:|---:|---:|---:|",
+    ]
+    for _, r in df.iterrows():
+        md.append(
+            f"| `{r.rule_id}` | {r.attribute} | {r.value} | {r.conditional_fail_rate*100:.0f}% | {r.baseline_fail_rate*100:.1f}% | {r.support_disks} | {r.support_events} |"
+        )
+    if df.empty:
+        md.append("| _no high-confidence patterns surfaced_ | | | | | | |")
+    (OUT / "high-confidence-patterns.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'high-confidence-patterns.md'} ({len(df)} candidates)")
+
+
 def main() -> None:
     OUT.mkdir(parents=True, exist_ok=True)
     checks = load_checks()
@@ -265,6 +317,7 @@ def main() -> None:
     # Richer analyses — best-effort.
     for fn, name in [
         (report_conditional, "conditional.md"),
+        (report_high_confidence, "high-confidence-patterns.md"),
         (report_disk_clusters, "disk-clusters.md"),
         (report_patterns, "patterns.md"),
     ]:

--- a/tools/audit/mine.py
+++ b/tools/audit/mine.py
@@ -286,9 +286,15 @@ def report_high_confidence(checks: pd.DataFrame) -> None:
                     "conditional_fail_rate": cond,
                     "baseline_fail_rate": baseline,
                 })
-    df = pd.DataFrame(rows).sort_values(
-        ["conditional_fail_rate", "support_disks"], ascending=[False, False]
-    )
+    if rows:
+        df = pd.DataFrame(rows).sort_values(
+            ["conditional_fail_rate", "support_disks"], ascending=[False, False]
+        )
+    else:
+        df = pd.DataFrame(columns=[
+            "rule_id", "attribute", "value", "support_events",
+            "support_disks", "conditional_fail_rate", "baseline_fail_rate",
+        ])
     md = [
         "# High-confidence patterns (act-on candidates)",
         "",

--- a/tools/audit/run_audit.sh
+++ b/tools/audit/run_audit.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Rebuild samfile-audit, regenerate JSONL across the corpus,
+# ingest into findings.db, mine reports. Idempotent.
+#
+# Requires ~/sam-corpus/.venv with pandas, scikit-learn, mlxtend.
+# Bootstrap it with:
+#   python3 -m venv ~/sam-corpus/.venv
+#   ~/sam-corpus/.venv/bin/pip install pandas scikit-learn mlxtend
+
+set -euo pipefail
+
+REPO="${HOME}/git/samfile"
+CORPUS="${HOME}/sam-corpus"
+PY="${CORPUS}/.venv/bin/python"
+
+if [ ! -x "$PY" ]; then
+    echo "error: $PY not found. Bootstrap the venv:" >&2
+    echo "  python3 -m venv ${CORPUS}/.venv && ${CORPUS}/.venv/bin/pip install pandas scikit-learn mlxtend" >&2
+    exit 1
+fi
+
+cd "$REPO"
+echo "==> building samfile-audit"
+go build -o "${CORPUS}/samfile-audit" ./cmd/samfile
+
+mkdir -p "${CORPUS}/outputs-jsonl" "${CORPUS}/analyses"
+rm -f "${CORPUS}/outputs-jsonl"/*.jsonl
+
+echo "==> running samfile-audit verify --format jsonl across the corpus"
+count=0
+for disk in "${CORPUS}/disks"/*.mgt; do
+    [ -f "$disk" ] || continue
+    name=$(basename "$disk" .mgt)
+    "${CORPUS}/samfile-audit" verify --format jsonl -i "$disk" \
+        > "${CORPUS}/outputs-jsonl/${name}.jsonl" 2>/dev/null || true
+    count=$((count + 1))
+done
+echo "ran on $count disks"
+
+echo "==> ingesting JSONL into ${CORPUS}/findings.db"
+"$PY" "${REPO}/tools/audit/ingest.py"
+
+echo "==> mining reports into ${CORPUS}/analyses/"
+"$PY" "${REPO}/tools/audit/mine.py"
+
+echo "==> done. reports in ${CORPUS}/analyses/"
+ls -la "${CORPUS}/analyses/"

--- a/verify.go
+++ b/verify.go
@@ -129,25 +129,35 @@ type Rule struct {
 	Description string    // one-line summary, used in human output
 	Citation    string    // file:line of the strongest evidence
 
-	// Legacy single-shot check. Mutually exclusive with CheckSubject.
-	// Kept for rules that haven't been migrated to the per-subject
-	// model. If CheckSubject is non-nil, Check is ignored.
+	// Check is the rule body. Receives a CheckContext, returns the
+	// findings (failures) it detected. Iterates internally over its
+	// universe of subjects. This is the only required field.
 	Check func(ctx *CheckContext) []Finding
 
-	// Scope identifies the per-subject iteration scope when
-	// CheckSubject is set. Ignored for legacy (Check-only) rules.
-	Scope SubjectScope
+	// Applicability declares the subject universe for the rule so
+	// the audit pipeline can compute denominators (pass/fail rates)
+	// and attribute snapshots. Optional — if nil, the rule's
+	// findings are still recorded as fail events, but pass events
+	// are not synthesized (no denominator available).
+	Applicability *RuleApplicability
 
-	// Applies reports whether subject is eligible for this rule. If
-	// nil, the rule applies to all subjects of its Scope. The number
-	// of applicable subjects is the denominator for fail-rate
-	// analysis in the audit pipeline.
-	Applies func(ctx *CheckContext, subject Subject) bool
-
-	// CheckSubject evaluates one applicable subject. Returns nil for
-	// pass, a Finding pointer for fail. The framework calls this once
-	// per applicable subject and emits a CheckEvent for each call.
+	// Scope / Applies / CheckSubject are reserved for future
+	// migration of rules to a fully per-subject signature. None of
+	// the currently-registered rules use these.
+	Scope        SubjectScope
+	Applies      func(ctx *CheckContext, subject Subject) bool
 	CheckSubject func(ctx *CheckContext, subject Subject) *Finding
+}
+
+// RuleApplicability declares the universe of subjects a rule
+// reasons about, so the framework can synthesize pass / n/a events
+// alongside the rule's own fail findings.
+type RuleApplicability struct {
+	Scope SubjectScope
+	// Filter selects which subjects of Scope are applicable. nil =
+	// every subject of the scope. For SlotScope filters typically
+	// gate on file type or used-vs-erased.
+	Filter func(*CheckContext, Subject) bool
 }
 
 // allRules is the package-private registry. Rules register at package
@@ -350,9 +360,52 @@ func (di *DiskImage) verifyInternal(rec *EventRecorder) VerifyReport {
 			}
 			continue
 		}
-		// Legacy path: rule provides Check only.
+		// Run the rule's Check(); always collect its findings.
 		legacyFindings := rule.Check(ctx)
 		report.Findings = append(report.Findings, legacyFindings...)
+		if rec == nil {
+			continue
+		}
+		// Match findings to subjects so we can emit pass / n/a / fail
+		// events with attribute snapshots, if the rule declares
+		// Applicability metadata. Otherwise emit only fail events
+		// (no denominator available).
+		if rule.Applicability != nil {
+			ap := rule.Applicability
+			subjects := ctx.subjectsForScope(ap.Scope)
+			// Index findings by location.Slot (or -1 for disk-wide).
+			findingsBySlot := map[int][]Finding{}
+			for _, f := range legacyFindings {
+				findingsBySlot[f.Location.Slot] = append(findingsBySlot[f.Location.Slot], f)
+			}
+			for _, subj := range subjects {
+				if ap.Filter != nil && !ap.Filter(ctx, subj) {
+					rec.Record(CheckEvent{
+						RuleID: rule.ID, Scope: ap.Scope.String(),
+						Ref: subj.Ref(), Outcome: "not_applicable",
+						Attrs: subj.Attributes(),
+					})
+					continue
+				}
+				slot := slotFromSubject(subj)
+				if fs, ok := findingsBySlot[slot]; ok && len(fs) > 0 {
+					f := fs[0]
+					rec.Record(CheckEvent{
+						RuleID: rule.ID, Scope: ap.Scope.String(),
+						Ref: subj.Ref(), Outcome: "fail",
+						Attrs: subj.Attributes(), Finding: &f,
+					})
+				} else {
+					rec.Record(CheckEvent{
+						RuleID: rule.ID, Scope: ap.Scope.String(),
+						Ref: subj.Ref(), Outcome: "pass",
+						Attrs: subj.Attributes(),
+					})
+				}
+			}
+			continue
+		}
+		// No applicability metadata: emit fail-only events.
 		for i := range legacyFindings {
 			f := legacyFindings[i]
 			ref := "disk"
@@ -366,6 +419,18 @@ func (di *DiskImage) verifyInternal(rec *EventRecorder) VerifyReport {
 		}
 	}
 	return report
+}
+
+// slotFromSubject returns the slot index this Subject refers to,
+// or -1 for disk-scope. Used to match legacy Check findings (which
+// carry Location.Slot) against the subject universe.
+func slotFromSubject(s Subject) int {
+	switch v := s.(type) {
+	case *SlotSubject:
+		return v.SlotIndex
+	default:
+		return -1
+	}
 }
 
 // subjectsForScope enumerates every Subject of the given scope on

--- a/verify.go
+++ b/verify.go
@@ -10,6 +10,12 @@ import "fmt"
 // the raw int.
 type Severity int
 
+// MarshalJSON renders Severity as its lowercase name (cosmetic /
+// inconsistency / structural / fatal) so JSONL output is readable.
+func (s Severity) MarshalJSON() ([]byte, error) {
+	return []byte(`"` + s.String() + `"`), nil
+}
+
 const (
 	SeverityCosmetic Severity = iota
 	SeverityInconsistency

--- a/verify.go
+++ b/verify.go
@@ -122,7 +122,26 @@ type Rule struct {
 	Dialects    []Dialect // dialects the rule applies to; nil/empty = all
 	Description string    // one-line summary, used in human output
 	Citation    string    // file:line of the strongest evidence
-	Check       func(ctx *CheckContext) []Finding
+
+	// Legacy single-shot check. Mutually exclusive with CheckSubject.
+	// Kept for rules that haven't been migrated to the per-subject
+	// model. If CheckSubject is non-nil, Check is ignored.
+	Check func(ctx *CheckContext) []Finding
+
+	// Scope identifies the per-subject iteration scope when
+	// CheckSubject is set. Ignored for legacy (Check-only) rules.
+	Scope SubjectScope
+
+	// Applies reports whether subject is eligible for this rule. If
+	// nil, the rule applies to all subjects of its Scope. The number
+	// of applicable subjects is the denominator for fail-rate
+	// analysis in the audit pipeline.
+	Applies func(ctx *CheckContext, subject Subject) bool
+
+	// CheckSubject evaluates one applicable subject. Returns nil for
+	// pass, a Finding pointer for fail. The framework calls this once
+	// per applicable subject and emits a CheckEvent for each call.
+	CheckSubject func(ctx *CheckContext, subject Subject) *Finding
 }
 
 // allRules is the package-private registry. Rules register at package
@@ -158,10 +177,16 @@ func Rules() []Rule {
 // another expensive derivation (e.g. a combined sector map), add
 // it as a field on CheckContext and memoise it in Verify.
 type CheckContext struct {
-	Disk    *DiskImage
-	Journal *DiskJournal
-	Dialect Dialect
+	Disk     *DiskImage
+	Journal  *DiskJournal
+	Dialect  Dialect
+	recorder *EventRecorder
 }
+
+// SetRecorder installs an EventRecorder that receives a CheckEvent
+// per (rule, applicable subject) pair during Verify. nil is fine —
+// the text-output path leaves the recorder unset.
+func (ctx *CheckContext) SetRecorder(r *EventRecorder) { ctx.recorder = r }
 
 // VerifyReport is the result of running Verify on a DiskImage.
 // Findings is the full ordered slice; the helper methods filter
@@ -270,20 +295,91 @@ func (r VerifyReport) Filter(opts FilterOpts) []Finding {
 // conservative: when it returns DialectUnknown (empty or ambiguous
 // disks), only all-dialects rules run.
 func (di *DiskImage) Verify() VerifyReport {
+	return di.verifyInternal(nil)
+}
+
+// VerifyWithRecorder runs verify and captures every Check event into
+// the provided recorder (in addition to producing the VerifyReport).
+// Use this from the JSONL CLI path.
+func (di *DiskImage) VerifyWithRecorder(rec *EventRecorder) VerifyReport {
+	return di.verifyInternal(rec)
+}
+
+func (di *DiskImage) verifyInternal(rec *EventRecorder) VerifyReport {
 	dialect := DetectDialect(di)
 	ctx := &CheckContext{
-		Disk:    di,
-		Journal: di.DiskJournal(),
-		Dialect: dialect,
+		Disk:     di,
+		Journal:  di.DiskJournal(),
+		Dialect:  dialect,
+		recorder: rec,
 	}
 	report := VerifyReport{Dialect: dialect}
 	for _, rule := range allRules {
 		if !ruleAppliesToDialect(rule, dialect) {
 			continue
 		}
-		report.Findings = append(report.Findings, rule.Check(ctx)...)
+		if rule.CheckSubject != nil {
+			subjects := ctx.subjectsForScope(rule.Scope)
+			for _, subj := range subjects {
+				applicable := rule.Applies == nil || rule.Applies(ctx, subj)
+				if !applicable {
+					rec.Record(CheckEvent{
+						RuleID: rule.ID, Scope: rule.Scope.String(),
+						Ref: subj.Ref(), Outcome: "not_applicable",
+						Attrs: subj.Attributes(),
+					})
+					continue
+				}
+				finding := rule.CheckSubject(ctx, subj)
+				outcome := "pass"
+				if finding != nil {
+					outcome = "fail"
+					report.Findings = append(report.Findings, *finding)
+				}
+				rec.Record(CheckEvent{
+					RuleID: rule.ID, Scope: rule.Scope.String(),
+					Ref: subj.Ref(), Outcome: outcome,
+					Attrs: subj.Attributes(), Finding: finding,
+				})
+			}
+			continue
+		}
+		// Legacy path: rule provides Check only.
+		legacyFindings := rule.Check(ctx)
+		report.Findings = append(report.Findings, legacyFindings...)
+		for i := range legacyFindings {
+			f := legacyFindings[i]
+			ref := "disk"
+			if f.Location.Slot >= 0 {
+				ref = fmt.Sprintf("slot=%d", f.Location.Slot)
+			}
+			rec.Record(CheckEvent{
+				RuleID: rule.ID, Scope: "legacy",
+				Ref: ref, Outcome: "fail", Finding: &f,
+			})
+		}
 	}
 	return report
+}
+
+// subjectsForScope enumerates every Subject of the given scope on
+// the current disk. DiskScope yields one DiskSubject; SlotScope
+// yields 80 SlotSubjects (every dir entry, used or erased).
+// ChainStepScope is not yet implemented — rules that need per-step
+// iteration should declare SlotScope and walk the chain internally.
+func (ctx *CheckContext) subjectsForScope(scope SubjectScope) []Subject {
+	switch scope {
+	case DiskScope:
+		return []Subject{&DiskSubject{Journal: ctx.Journal, Disk: ctx.Disk, Dialect: ctx.Dialect}}
+	case SlotScope:
+		out := make([]Subject, 0, 80)
+		for i := 0; i < 80; i++ {
+			fe := (*ctx.Journal)[i]
+			out = append(out, &SlotSubject{SlotIndex: i, FileEntry: fe, Disk: ctx.Disk, Journal: ctx.Journal})
+		}
+		return out
+	}
+	return nil
 }
 
 // ruleAppliesToDialect reports whether rule should run when the


### PR DESCRIPTION
## Summary

Adds an instrumented audit framework on top of `samfile verify` so every rule emits a `CheckEvent` per subject (`pass` / `fail` / `not_applicable`) with a full attribute snapshot, then ingests those events into a `checks` table in `~/sam-corpus/findings.db` and mines them for patterns. **First corpus run flagged a high-confidence over-strict pair (ZXSNAP-* rules at 99.5% fail rate); source-grounded and fixed in this PR.**

Design spec: `docs/specs/2026-05-12-verify-audit-framework-design.md`
Implementation plan: `docs/plans/2026-05-12-verify-audit-framework.md`

## What's here

**Framework (Go):**
- `subject.go` / `subject_disk.go` / `subject_slot.go` / `subject_chain.go` — Subject interface + DiskSubject / SlotSubject / ChainStepSubject with denormalised attribute snapshots.
- `verify.go` — `Rule` struct grows an `Applicability` field (`Scope` + `Filter`). Framework iterates per-scope subjects, evaluates Applies, matches the rule's existing `Check`-returned findings against the subject universe, emits pass / fail / not_applicable `CheckEvent`s per (rule, subject).
- `check_event.go` — `CheckEvent` + `EventRecorder`.
- `cmd/samfile/verify.go` — new `--format jsonl` flag; default text output unchanged.
- `rules_applicability_helpers.go` — `usedSlot`, `typedSlot(...)` helpers.
- All 51 rules annotated with `Applicability` (no Check body rewrites).

**Pipeline (Python, `tools/audit/`):**
- `ingest.py` — JSONL → `checks` table with full attribute columns.
- `mine.py` — six Markdown reports under `~/sam-corpus/analyses/`, in fail-safe order: coverage.md and disk-health.md (plain pandas counts — fallback floor), then conditional.md, high-confidence-patterns.md, disk-clusters.md, patterns.md (best-effort).
- `run_audit.sh` — end-to-end driver (rebuild → JSONL across corpus → ingest → mine).

**First corpus run (800 disks, 2026-05-12):**
- Coverage report covers all 51 rules with denominators.
- Top fail-rate signal: `ZXSNAP-LENGTH-49152` and `ZXSNAP-LOAD-ADDR-16384` both at **99.5%** (192/193, 25 disks). Of those 25, **22 are masterdos-dialect, 3 unknown-dialect, 0 are samdos2**. Source grounding via `samdos/src/d.s:629-630 + :612` confirms the rules are SAMDOS-2-specific; the catalog already says so, but the code's header comment overrode that and ran the rules on all dialects.
- Fix: `dc29b44` adds `Dialects: []Dialect{DialectSAMDOS2}` to both Register calls.

**Secondary signal** (not acted on): 60 disks with `sectors_count=33041` (impossible — max valid is 1560) and `mgt_flags=126` consistently trigger most rules. This is the "broken-disk cluster" the spec anticipated; the audit pipeline correctly surfaces it. The rules firing here are working as intended (the disks have corrupted dir entries); a follow-up could pre-filter this cluster from rule-level statistics.

## Test plan

- [x] `go test ./...` passes
- [x] `samfile verify --format jsonl -i testdata/ETrackerv1.2.mgt` emits valid JSONL CheckEvents with `outcome ∈ {pass, fail, not_applicable}` and full attribute snapshots
- [x] `tools/audit/run_audit.sh` runs end-to-end on the 800-disk corpus
- [x] Reports under `~/sam-corpus/analyses/` are coherent (eyeballed coverage.md and disk-health.md)
- [x] Source-grounded fix: `samdos/src/d.s` confirms ZXSNAP rules are SAMDOS-2 specific
- [ ] CI green (will monitor and fix autonomously)

## Notes for review

- Bundle is intentionally large per spec decision: one PR with framework + rule fixes for a single review surface.
- The framework keeps full back-compat: rules without `Applicability` still produce fail events from their existing `Check` bodies. No rule's `Check` body was touched.
- Python venv at `~/sam-corpus/.venv` (with pandas/sklearn/mlxtend) is a runtime prerequisite for `run_audit.sh`; bootstrap command is in the script's header.
- The autonomous discovery loop stopped after one round (one strong source-grounded pattern actioned). Re-running the loop after this PR lands will likely surface secondary patterns (e.g. broken-disk cluster filtering, BODY-EXEC-* attribute correlations) for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)