### PR TITLE
feat(audit): iter-2 — recommendations report + two source-grounded rule fixes

### DIFF
--- a/docs/disk-validity-rules.md
+++ b/docs/disk-validity-rules.md
@@ -768,32 +768,51 @@ byte-6-equals-low-byte-of-0xF3..0xF4 equality. See
 ### BODY-EXEC-DIV16K-MATCHES-DIR — Body byte 5 == dir byte 0xF2
 
 - What: Body byte 5 (`ExecutionAddressDiv16K`) mirrors dir byte
-  0xF2. The ROM auto-exec gate (rom-disasm:22467-22484) checks BOTH
-  for `0xFF` before deciding to auto-execute, so the two must agree
-  to avoid surprises.
-- Severity: structural (mismatch can cause unwanted auto-exec)
-- Source authority: ROM
-- Citation: ROM disasm L22471-22484 (see §0 above).
+  0xF2 for FT_CODE files (both encode the auto-exec page-form
+  Div16K). Prior catalog wording claimed the "ROM auto-exec gate
+  checks both for `0xFF` before deciding to auto-execute" — this
+  was wrong, see Severity below.
+- Severity: cosmetic (body mirror is save-time-only; LOAD reads
+  from the dir entry via gtfle/hconr/txhed — see
+  BODY-MIRROR-AT-DIR-D3-DB §5 for the citation chain. Body[5]
+  never enters ROM's view on LOAD; a mismatch has zero load-time
+  consequence. Aligns with the rest of the body-mirror cluster.)
+- Source authority: ROM + SAMDOS-code
+- Citation: ROM disasm L22471-22484 (the auto-exec gate reads
+  HDL+HDN+6 which is dir-fed); SAMDOS `samdos/src/f.s:494-497`
+  (`ldhd` reads body bytes 0..8 via `lbyt` and discards them).
 - Dialect: all
-- Suppressed by: PROTECTED files take a different path
-  (rom-disasm:22467-22469: `BIT 1,A; JR NZ,HDNSTP`); the requested
-  exec is then skipped and only the LOADED path is honoured.
-- Test sketch: `body[5] == dir[0xF2]`.
+- Iteration 2 DEMOTE: corpus iter-2 (2026-05-12) showed 1897 fires
+  across 164 disks, 727 of them the `body=0x00, dir=0xFF` pattern.
+  Per the source chain the body byte never reaches ROM, so the
+  "could cause unwanted auto-exec" framing was incorrect. Severity
+  dropped from structural to cosmetic to match the body-mirror
+  cluster's load-time-irrelevant classification.
+- Test sketch: `body[5] == dir[0xF2]` (only for FT_CODE; skip when
+  body[5]==0xFF — the canonical "defer to dir" pattern).
 
 ### BODY-EXEC-MOD16K-LO-MATCHES-DIR — Body byte 6 == dir byte 0xF3
 
 - What: Body byte 6 holds only the low byte of
   `ExecutionAddressMod16K`. It mirrors dir byte 0xF3. The high byte
   (dir 0xF4) has no body-header counterpart.
-- Severity: inconsistency
-- Source authority: ROM + samfile-implicit
+- Severity: cosmetic (body mirror is save-time-only; same chain as
+  BODY-EXEC-DIV16K-MATCHES-DIR — body[6] is read-and-discarded by
+  ldhd, never feeds ROM HDL/HDR).
+- Source authority: ROM + samfile-implicit + SAMDOS-code
 - Citation: ROM disasm L22472: `LD HL,(HDR+HDN+7)` — 16-bit LE pair
   starting at HDR offset 38 (= byte after HDR+HDN+6 = byte 37). The
   body header's byte 6 maps to HDL's `HDR+HDN+7` low byte via
-  SAMDOS `dschd` (`h.s:74-90`). samfile models this via
+  SAMDOS `dschd` (`h.s:74-90`), but the runtime feed is dir-side
+  (gtfle/hconr/txhed). samfile models this via
   `FileHeader.ExecutionAddressMod16KLo` (samfile.go:194).
 - Dialect: all
-- Test sketch: `body[6] == (dir[0xF3] & 0xFF)`.
+- Iteration 2 DEMOTE: corpus iter-2 (2026-05-12) showed 1873 fires
+  across 164 disks (parallels BODY-EXEC-DIV16K-MATCHES-DIR).
+  Severity dropped from inconsistency to cosmetic per the same
+  body-mirror cluster reasoning.
+- Test sketch: `body[6] == (dir[0xF3] & 0xFF)` (only for FT_CODE;
+  skip when body[5]==0xFF).
 
 ### BODY-PAGES-MATCHES-DIR — Body byte 7 == dir byte 0xEF
 

--- a/rules_body_header.go
+++ b/rules_body_header.go
@@ -103,17 +103,27 @@ func checkBodyTypeMatchesDir(ctx *CheckContext) []Finding {
 // gate at rom-disasm:22471-22484, auto-exec is disabled at the body
 // level when body[5] is 0xFF — bytes 5-6 are the canonical
 // "defer to dir" pattern ROM SAVE writes (catalog
-// §BODY-BYTES-5-6-CANONICAL-FF). Whatever dir says in that case is
-// authoritative and not a mismatch. The real-inconsistency cases
-// (`body=N (non-FF), dir=M (FF or different N)`) still fire, e.g.
-// the 727 `body=0x00, dir=0xFF` corpus fires where the body would
-// auto-exec from page 0 even though dir disables auto-exec.
+// §BODY-BYTES-5-6-CANONICAL-FF).
+//
+// Iteration 2 DEMOTE: structural → cosmetic. The body-mirror cluster
+// (BODY-MIRROR-AT-DIR-D3-DB and friends, commit 2b8aa1a) was
+// demoted to cosmetic after the SAMDOS source-chain analysis
+// (samdos/src/f.s:494-497 ldhd → c.s:557-570 lbyt → h.s:336-361
+// hconr → h.s:38-56 txhed) proved that body bytes 0..8 are read-
+// and-discarded on LOAD; the auto-exec gate reads HDL+HDN+6 which
+// is dir-derived (gtfle fills hd001.. from dir 0xD3-0xDB; hconr
+// reloads from uifa+* which is dir-side). Body[5] never enters
+// ROM's view. The "mismatch can cause unwanted auto-exec" framing
+// in the earlier catalog text was wrong; this rule should match
+// the rest of the body-mirror cluster. Corpus iter-2: 1897 fires
+// across 164 disks, 727 of which are the `body=0x00, dir=0xFF`
+// pattern — load-time consequence: none.
 func init() {
 	Register(Rule{
 		ID:            "BODY-EXEC-DIV16K-MATCHES-DIR",
-		Severity:      SeverityStructural,
-		Description:   "FT_CODE body-header ExecutionAddressDiv16K (byte 5) equals dir-entry ExecutionAddressDiv16K (skipped when body[5]==0xFF — the canonical 'defer to dir' pattern)",
-		Citation:      "rom-disasm:22471-22484",
+		Severity:      SeverityCosmetic,
+		Description:   "FT_CODE body-header ExecutionAddressDiv16K (byte 5) equals dir-entry ExecutionAddressDiv16K (cosmetic: body bytes 0..8 are unused on LOAD; mismatch has zero load-time consequence)",
+		Citation:      "rom-disasm:22471-22484; samdos/src/f.s:494-497",
 		Check:         checkBodyExecDiv16KMatchesDir,
 		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_CODE)},
 	})
@@ -136,7 +146,7 @@ func checkBodyExecDiv16KMatchesDir(ctx *CheckContext) []Finding {
 			return
 		}
 		findings = append(findings, bodyDirMirrorFinding(
-			"BODY-EXEC-DIV16K-MATCHES-DIR", SeverityStructural, "rom-disasm:22471-22484", "ExecutionAddressDiv16K",
+			"BODY-EXEC-DIV16K-MATCHES-DIR", SeverityCosmetic, "rom-disasm:22471-22484", "ExecutionAddressDiv16K",
 			slot, fe.Name.String(),
 			fe.ExecutionAddressDiv16K, hdr[5],
 		)...)
@@ -154,14 +164,20 @@ func checkBodyExecDiv16KMatchesDir(ctx *CheckContext) []Finding {
 // disabled at the body level (body[5]==0xFF — the canonical
 // "defer to dir" pattern per BODY-EXEC-DIV16K-MATCHES-DIR), the
 // body's byte 6 (lo of mod16K) is meaningless and any value is
-// allowed. Only fire the comparison when the body genuinely encodes
-// an exec address.
+// allowed.
+//
+// Iteration 2 DEMOTE: inconsistency → cosmetic. Same SAMDOS source-
+// chain analysis as BODY-EXEC-DIV16K-MATCHES-DIR (samdos/src/f.s:
+// 494-497 ldhd reads body bytes 0..8 via lbyt and discards them;
+// hconr/txhed feed ROM HDL/HDR from the dir entry). Body[6] never
+// enters ROM's view. Corpus iter-2: 1873 fires across 164 disks
+// (parallels the div16k pair). Load-time consequence: none.
 func init() {
 	Register(Rule{
 		ID:            "BODY-EXEC-MOD16K-LO-MATCHES-DIR",
-		Severity:      SeverityInconsistency,
-		Description:   "FT_CODE body-header ExecutionAddressMod16KLo (byte 6) equals low byte of dir-entry ExecutionAddressMod16K (skipped when body[5]==0xFF — body byte 6 is meaningless under the 'defer to dir' pattern)",
-		Citation:      "rom-disasm:22472",
+		Severity:      SeverityCosmetic,
+		Description:   "FT_CODE body-header ExecutionAddressMod16KLo (byte 6) equals low byte of dir-entry ExecutionAddressMod16K (cosmetic: body bytes 0..8 are unused on LOAD; mismatch has zero load-time consequence)",
+		Citation:      "rom-disasm:22472; samdos/src/f.s:494-497",
 		Check:         checkBodyExecMod16KLoMatchesDir,
 		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_CODE)},
 	})
@@ -184,7 +200,7 @@ func checkBodyExecMod16KLoMatchesDir(ctx *CheckContext) []Finding {
 			return
 		}
 		findings = append(findings, bodyDirMirrorFinding(
-			"BODY-EXEC-MOD16K-LO-MATCHES-DIR", SeverityInconsistency, "rom-disasm:22472", "ExecutionAddressMod16KLo",
+			"BODY-EXEC-MOD16K-LO-MATCHES-DIR", SeverityCosmetic, "rom-disasm:22472", "ExecutionAddressMod16KLo",
 			slot, fe.Name.String(),
 			uint8(fe.ExecutionAddressMod16K&0xFF), hdr[6],
 		)...)

--- a/rules_ft_basic.go
+++ b/rules_ft_basic.go
@@ -147,11 +147,32 @@ func checkBasicVarsGapInvariant(ctx *CheckContext) []Finding {
 // The tokenised program ends with a 0xFF sentinel byte. The byte at
 // body[ProgramLength-1] is the sentinel (NVARS-PROG is the program-area
 // end offset).
+//
+// Iteration 2 SCOPE: restrict to DialectSAMDOS1 + DialectSAMDOS2.
+// Corpus iter-2 (2026-05-12) showed 29.2% fail-rate on masterdos
+// vs 0.5-0.7% on samdos1/samdos2. Masterdos's BASIC file layout
+// uses a different convention (also reflected in
+// BASIC-VARS-GAP-INVARIANT's `Dialect: SAMDOS-2 = 604; MasterDOS =
+// 2156` split).
+//
+// Source check against MasterDOS 2.3 disassembly
+// (dandoore/masterdos@HEAD masterdos23.asm:10988):
+//
+//   LD   (HL),&FF   ;ENSURE PROG TERMINATED
+//
+// — masterdos DOES write the 0xFF sentinel. So the byte exists;
+// the issue is that samfile's `ProgramLength()` (which assumes
+// the samdos PAGEFORM convention) lands on a different offset for
+// masterdos files. Until masterdos's BASIC layout is modelled in
+// sambasic, samfile reads the wrong byte and produces a spurious
+// "no 0xFF sentinel" finding on masterdos disks. Fire only on
+// samdos1+samdos2 until then.
 func init() {
 	Register(Rule{
 		ID:            "BASIC-PROG-END-SENTINEL",
 		Severity:      SeverityStructural,
-		Description:   "FT_SAM_BASIC program-area ends with a 0xFF sentinel byte",
+		Dialects:      []Dialect{DialectSAMDOS1, DialectSAMDOS2},
+		Description:   "FT_SAM_BASIC program-area ends with a 0xFF sentinel byte (samdos1 / samdos2 only)",
 		Citation:      "sambasic/file.go:36-42",
 		Check:         checkBasicProgEndSentinel,
 		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_SAM_BASIC)},
@@ -201,11 +222,30 @@ func checkBasicProgEndSentinel(ctx *CheckContext) []Finding {
 //
 // Line.Number is `uint16`, so the upper bound 65535 is implicit in
 // the type; only the `== 0` check remains as an explicit guard.
+//
+// Iteration 2 SCOPE: restrict to DialectSAMDOS1 + DialectSAMDOS2.
+// Corpus iter-2 (2026-05-12) showed 31.4% fail-rate on masterdos
+// vs 1.8%/2.7% on samdos1/samdos2 — and the rule co-fires with
+// BASIC-PROG-END-SENTINEL on 126 of 131 disks (Jaccard 0.47).
+// Same root cause as that rule: when samfile parses a masterdos
+// BASIC body as if it were samdos-format, the parser walks past
+// the real program end into NVARS bytes and reports spurious
+// line=0 / "body extends past input" findings.
+//
+// Source check against MasterDOS 2.3 disassembly: masterdos's
+// BASIC layout uses a 2156-byte vars-gap (vs samdos2's 604; see
+// BASIC-VARS-GAP-INVARIANT) and writes a 0xFF program terminator
+// (masterdos23.asm:10988), but its FileTypeInfo PAGEFORM doesn't
+// translate into the samdos convention samfile's
+// `ProgramLength()` assumes. Until sambasic gains a masterdos-
+// aware decoder, this rule's structural severity is only
+// trustworthy on samdos1+samdos2.
 func init() {
 	Register(Rule{
 		ID:            "BASIC-LINE-NUMBER-BE",
 		Severity:      SeverityStructural,
-		Description:   "FT_SAM_BASIC program parses cleanly and every line number is in 1..65535 (uint16 BE; widened from 1..16383 in iteration 1)",
+		Dialects:      []Dialect{DialectSAMDOS1, DialectSAMDOS2},
+		Description:   "FT_SAM_BASIC program parses cleanly and every line number is in 1..65535 (samdos1 / samdos2 only — masterdos BASIC layout not yet modelled in sambasic)",
 		Citation:      "sambasic/parse.go",
 		Check:         checkBasicLineNumberBE,
 		Applicability: &RuleApplicability{Scope: SlotScope, Filter: typedSlot(FT_SAM_BASIC)},

--- a/rules_ft_basic.go
+++ b/rules_ft_basic.go
@@ -288,14 +288,26 @@ func checkBasicStartLineFFDisables(ctx *CheckContext) []Finding {
 		if marker == 0x00 {
 			line := fe.SAMBASICStartLine
 			// Iteration 1 SCOPE: line numbers are 16-bit BE; widen the
-			// accepted range from 1..16383 to 1..65534 (excluding 0xFFFF
-			// which is the no-auto-RUN sentinel). Companion to
-			// BASIC-LINE-NUMBER-BE.
-			if line == 0 || line == 0xFFFF {
+			// accepted range from 1..16383 to full uint16.
+			//
+			// Iteration 2 SCOPE: allow line==0 (the canonical
+			// "SAVE name LINE 0" idiom — ROM's RUN dispatch uses
+			// FNDLINE/NEXT-LINE-GE 0 semantics, which finds the first
+			// line in the program; rom-disasm:6295-6325 confirms the
+			// >=BC walk returns the first line when BC=0). Corpus
+			// iter-2 (2026-05-12): 704 disks across all dialects
+			// (28 samdos2, 23 masterdos, 3 samdos1, 155 unknown)
+			// use this idiom — clearly a deliberate convention, not
+			// a writer bug.
+			//
+			// 0xFFFF (when marker==0x00) is still flagged: it's the
+			// no-auto-RUN sentinel typically paired with marker==0xFF,
+			// so a contradictory pairing is genuinely suspicious.
+			if line == 0xFFFF {
 				findings = append(findings, Finding{
 					RuleID: "BASIC-STARTLINE-FF-DISABLES", Severity: SeverityStructural,
 					Location: SlotLocation(slot, fe.Name.String()),
-					Message:  fmt.Sprintf("BASIC auto-RUN enabled (dir[0xF2]=0x00) but start-line %d is invalid (1..65534; 0xFFFF disables auto-RUN)", line),
+					Message:  fmt.Sprintf("BASIC auto-RUN enabled (dir[0xF2]=0x00) but start-line %d is the no-auto-RUN sentinel (0xFFFF); the marker and the line contradict", line),
 					Citation: "rom-disasm:22136-22141",
 				})
 			}

--- a/tools/audit/mine.py
+++ b/tools/audit/mine.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import sqlite3
 import traceback
+from collections import Counter
 from pathlib import Path
 
 import pandas as pd
@@ -313,6 +314,220 @@ def report_high_confidence(checks: pd.DataFrame) -> None:
     print(f"wrote {OUT / 'high-confidence-patterns.md'} ({len(df)} candidates)")
 
 
+def report_recommendations(checks: pd.DataFrame) -> None:
+    """For each rule with fail-rate >= 5% AND >= 50 distinct disks (or
+    >= 50% AND >= 5 disks for narrow rules), synthesise:
+
+    - top failure-message frequency table
+    - dialect × outcome breakdown
+    - file_type × outcome breakdown
+    - top conditional-fail-rate slices (cond - baseline > 30pp or cond
+      in {0%, 100%}) on support >= 10 disks
+    - the rule's per-disk co-fire ranking (top other rules that fire on
+      the same disks where this rule fires) at Jaccard >= 0.3
+
+    The output is intentionally one section per rule so the discovery
+    loop can read top-to-bottom and act without ad-hoc SQL.
+    """
+    # Resolve each rule's dominant severity from its fail rows.
+    sev_by_rule = (
+        checks[checks["outcome"] == "fail"]
+        .groupby("rule_id")["severity"]
+        .agg(lambda x: x.mode().iloc[0] if not x.mode().empty else "")
+        .to_dict()
+    )
+
+    # Per-rule fail-rate ranking (so we surface the priority list at top).
+    rule_summary = []
+    for rule_id, grp in checks.groupby("rule_id"):
+        applicable = grp[grp["outcome"].isin(["pass", "fail"])]
+        n = len(applicable)
+        if n == 0:
+            continue
+        fails = (applicable["outcome"] == "fail").sum()
+        disks = applicable.loc[applicable["outcome"] == "fail", "disk"].nunique()
+        rule_summary.append({
+            "rule_id": rule_id,
+            "severity": sev_by_rule.get(rule_id, ""),
+            "applies": n,
+            "fails": int(fails),
+            "fail_rate": fails / n,
+            "disks": int(disks),
+        })
+    summary_df = pd.DataFrame(rule_summary).sort_values("fail_rate", ascending=False)
+
+    # Disks per rule, for co-fire computation.
+    disks_per_rule = (
+        checks[checks["outcome"] == "fail"]
+        .groupby("rule_id")["disk"].apply(set).to_dict()
+    )
+
+    # Which rules deserve a full section?
+    actionable = summary_df[
+        ((summary_df["fail_rate"] >= 0.05) & (summary_df["disks"] >= 50))
+        | ((summary_df["fail_rate"] >= 0.5) & (summary_df["disks"] >= 5))
+    ]
+    # Drop rules whose severity is already cosmetic — those have been
+    # explicitly classified as low-priority. Keep blank-severity rows
+    # (rules with zero fails — they have no actionable signal anyway).
+    actionable = actionable[actionable["severity"] != "cosmetic"]
+
+    md = [
+        "# Rule-fix recommendations",
+        "",
+        "Each section is a candidate for the autonomous fix loop. Sections appear when:",
+        "",
+        "- fail-rate ≥ 5% AND ≥ 50 distinct disks affected, OR",
+        "- fail-rate ≥ 50% AND ≥ 5 distinct disks affected.",
+        "",
+        "Rules already classified `cosmetic` are excluded (low-priority by design).",
+        "",
+        "Before acting on any section, source-ground the hypothesis in samdos source",
+        "(`~/git/samdos/src/`), ROM disasm",
+        "(`~/git/sam-aarch64/docs/sam/sam-coupe_rom-v3.0_annotated-disassembly.txt`),",
+        "or samfile itself. Sections that can't be source-grounded belong in",
+        "`needs-human.md`, not in a commit.",
+        "",
+        "## Priority list",
+        "",
+        "| Rule | Severity | Fails | Applies | Fail-rate | Disks |",
+        "|---|---|---:|---:|---:|---:|",
+    ]
+    for _, r in actionable.iterrows():
+        md.append(
+            f"| `{r.rule_id}` | {r.severity} | {r.fails} | {r.applies} | {r.fail_rate*100:.1f}% | {r.disks} |"
+        )
+    md.append("")
+    md.append("---")
+    md.append("")
+
+    for _, r in actionable.iterrows():
+        rule_id = r.rule_id
+        md.append(f"## `{rule_id}`")
+        md.append("")
+        md.append(
+            f"- Severity: **{r.severity}** · applies={r.applies} · fails={r.fails} ({r.fail_rate*100:.1f}%) · disks={r.disks}"
+        )
+        md.append("")
+
+        rule_checks = checks[checks["rule_id"] == rule_id]
+        rule_fails = rule_checks[rule_checks["outcome"] == "fail"]
+        rule_app = rule_checks[rule_checks["outcome"].isin(["pass", "fail"])]
+
+        # 1. Top messages.
+        msgs = (
+            rule_fails["message"].value_counts().head(10)
+        )
+        if not msgs.empty:
+            md.append("**Top failure messages:**")
+            md.append("")
+            md.append("| Count | Message |")
+            md.append("|---:|---|")
+            for msg, n in msgs.items():
+                msg_disp = (str(msg) or "").replace("|", "\\|")[:200]
+                md.append(f"| {n} | {msg_disp} |")
+            md.append("")
+
+        # 2. Dialect breakdown — pull from disks table.
+        disk_dialect = (
+            checks.dropna(subset=["dialect"])
+            .groupby("disk")["dialect"].first()
+            .to_dict()
+        )
+        if disk_dialect:
+            tally: Counter = Counter()
+            base: Counter = Counter()
+            for _, ev in rule_app.iterrows():
+                d = disk_dialect.get(ev["disk"])
+                if d is None:
+                    continue
+                base[d] += 1
+                if ev["outcome"] == "fail":
+                    tally[d] += 1
+            if base:
+                md.append("**Outcome by dialect:**")
+                md.append("")
+                md.append("| Dialect | Applies | Fails | Fail-rate |")
+                md.append("|---|---:|---:|---:|")
+                for d in sorted(base):
+                    n = base[d]
+                    f = tally.get(d, 0)
+                    md.append(f"| {d} | {n} | {f} | {100*f/n:.1f}% |")
+                md.append("")
+
+        # 3. File-type breakdown.
+        if "file_type" in rule_app.columns and rule_app["file_type"].notna().any():
+            ftt = (
+                rule_app.groupby("file_type")["outcome"]
+                .apply(lambda s: (len(s), (s == "fail").sum()))
+            )
+            md.append("**Outcome by file_type:**")
+            md.append("")
+            md.append("| file_type | Applies | Fails | Fail-rate |")
+            md.append("|---|---:|---:|---:|")
+            for ft, (n, f) in ftt.items():
+                if not ft:
+                    continue
+                md.append(f"| {ft} | {n} | {f} | {100*f/n:.1f}% |")
+            md.append("")
+
+        # 4. Conditional fail-rate slices (other attributes).
+        baseline = (rule_app["outcome"] == "fail").mean()
+        slices = []
+        for col in ATTR_COLS:
+            if col in ("file_type", "dialect"):
+                continue  # already covered above
+            if col not in rule_app.columns or rule_app[col].isna().all():
+                continue
+            for val, sub in rule_app.groupby(col):
+                support_disks = sub["disk"].nunique()
+                if support_disks < 10:
+                    continue
+                cond = (sub["outcome"] == "fail").mean()
+                delta = cond - baseline
+                if cond in (0.0, 1.0) or abs(delta) > 0.3:
+                    slices.append((col, str(val), support_disks, baseline, cond, delta))
+        slices.sort(key=lambda s: -abs(s[5]))
+        if slices:
+            md.append("**Conditional fail-rate slices (|Δ| > 30pp or cond ∈ {0%, 100%}, ≥ 10 disks):**")
+            md.append("")
+            md.append("| Attribute | Value | Support (disks) | Baseline | Conditional | Δ |")
+            md.append("|---|---|---:|---:|---:|---:|")
+            for col, val, sd, bl, cn, dl in slices[:15]:
+                md.append(f"| {col} | {val} | {sd} | {bl*100:.1f}% | {cn*100:.1f}% | {dl*100:+.1f}pp |")
+            md.append("")
+
+        # 5. Co-fire ranking.
+        my_disks = disks_per_rule.get(rule_id, set())
+        if my_disks:
+            cofires = []
+            for other, other_disks in disks_per_rule.items():
+                if other == rule_id:
+                    continue
+                intersect = len(my_disks & other_disks)
+                union = len(my_disks | other_disks)
+                if union == 0:
+                    continue
+                jaccard = intersect / union
+                if jaccard >= 0.3 and intersect >= 5:
+                    cofires.append((other, intersect, len(other_disks), jaccard))
+            cofires.sort(key=lambda x: -x[3])
+            if cofires:
+                md.append(f"**Co-firing rules** (Jaccard ≥ 0.3, ≥ 5 shared disks; this rule fires on {len(my_disks)} disks):")
+                md.append("")
+                md.append("| Other rule | Shared disks | Other rule total | Jaccard |")
+                md.append("|---|---:|---:|---:|")
+                for other, inter, total, j in cofires[:10]:
+                    md.append(f"| `{other}` | {inter} | {total} | {j:.2f} |")
+                md.append("")
+
+        md.append("---")
+        md.append("")
+
+    (OUT / "recommendations.md").write_text("\n".join(md) + "\n")
+    print(f"wrote {OUT / 'recommendations.md'} ({len(actionable)} actionable rules)")
+
+
 def main() -> None:
     OUT.mkdir(parents=True, exist_ok=True)
     checks = load_checks()
@@ -326,6 +541,7 @@ def main() -> None:
         (report_high_confidence, "high-confidence-patterns.md"),
         (report_disk_clusters, "disk-clusters.md"),
         (report_patterns, "patterns.md"),
+        (report_recommendations, "recommendations.md"),
     ]:
         try:
             fn(checks)


### PR DESCRIPTION
## Summary

Second iteration of the autonomous discovery loop, on top of #29.

Adds the `recommendations.md` deep-dive report so the discovery loop
runs off Markdown reports instead of ad-hoc SQL (Pete's catch — that
drift was a defect in the framework, not a methodology choice). Three
source-grounded rule fixes surfaced by the new report; remaining
top-N rules are either already calibrated or have a follow-up logged.

Branch: `feat/verify-audit-iter-2`.
Corpus state: see `~/sam-corpus/analyses/recommendations.md` and
`~/sam-corpus/analyses/needs-human.md`.

## Framework

- **`recommendations.md` report (`7e5afd8`)** — `tools/audit/mine.py`
  gains `report_recommendations`. A rule earns a section when
  fail-rate ≥ 5% AND ≥ 50 disks (or 50% AND ≥ 5 disks for narrow
  rules) and isn't already cosmetic. Each section surfaces top
  failure messages, dialect breakdown, file_type breakdown,
  conditional-rate slices, and co-firing rules. Replaces ad-hoc SQL.

## Rule fixes (all corpus-driven and source-grounded)

**1. BODY-EXEC-{DIV16K,MOD16K-LO}-MATCHES-DIR → cosmetic (`3ad7a51`)**
The "mismatch can cause unwanted auto-exec" framing was wrong:
SAMDOS source-chain analysis (commit 2b8aa1a) already proved body
bytes 0..8 are read-and-discarded by `ldhd`/`lbyt` and the ROM
auto-exec gate reads `HDL+HDN+6` which is dir-fed (gtfle/hconr/
txhed). Body[5..6] never enter ROM's view; the rules belonged in
the body-mirror cluster's cosmetic bucket, not at structural /
inconsistency. Corpus iter-2: 1897 + 1873 fires across 164 disks.

**2. BASIC-STARTLINE-FF-DISABLES: accept SAVE...LINE 0 (`38d62e0`)**
The rule rejected `dir[0xF3..0xF4] = 0` when `dir[0xF2] = 0x00`.
Corpus iter-2 showed 704 fails across 209 disks for the single
"line=0" pattern, across every dialect (28 samdos2 / 23 masterdos /
3 samdos1 / 155 unknown). Source grounding: `rom-disasm:6295-6325`
(FNDLINE walks `>= BC`, so RUN 0 finds the first line) and
`rom-disasm:22086-22099` (ROM SAVE writes BC verbatim, no zero-
check). `SAVE name LINE 0` is the canonical "run from start" idiom.
Fix: drop the `line == 0` check; keep the `line == 0xFFFF` contradiction check.

**3. BASIC-{PROG-END-SENTINEL,LINE-NUMBER-BE} → samdos1+samdos2 only (`aa13a15`)**
Corpus iter-2 dialect skew:
- BASIC-PROG-END-SENTINEL: masterdos 29.2% vs samdos1/2 0.5-0.7%
- BASIC-LINE-NUMBER-BE: masterdos 31.4% vs samdos1/2 1.8-2.7%
- Co-fire on 126/131 disks (Jaccard 0.47) — same root cause.

Source check against MasterDOS 2.3 disassembly
(`dandoore/masterdos@HEAD`):
- `masterdos23.asm:10988`: `LD (HL),&FF ;ENSURE PROG TERMINATED` —
  masterdos DOES write the sentinel
- File type 16 same as samdos (line 5535/3971)
- But its FileTypeInfo PAGEFORM doesn't match samdos's convention
  (already documented indirectly via BASIC-VARS-GAP-INVARIANT's
  604 / 2156 split). samfile's `ProgramLength()` lands on the
  wrong byte for masterdos files, so the sentinel check and the
  parser both spuriously fail.

Interim fix: `Dialects: []Dialect{DialectSAMDOS1, DialectSAMDOS2}`.
Follow-up logged in `~/sam-corpus/analyses/needs-human.md`: model
masterdos's PAGEFORM in `sambasic` and re-enable the rules.

## Lessons captured for future iterations

Two methodology gaps Pete called out, now saved as memories:
1. **Don't ad-hoc SQL when reports are missing dimensions** —
   extend `mine.py` instead. Drove the `recommendations.md` addition.
2. **Find the actual DOS source before scoping a rule out** —
   web search (`"<dos> source code"`), and remember the DOS is
   on the disk itself (boot block disassembly is tractable).
   Drove the masterdos-source check in the BASIC rules commit.

## Discovery result this iteration

After fixes, the residual high-fail-rate rules are all calibrated:

| Rule | Status |
|---|---|
| `BOOT-OWNER-AT-T4S1` | Already structural (non-bootable archives) |
| `CHAIN-MATCHES-SAM` | Already inconsistency (commit `3287b03`) |
| `DIR-SECTORS-MATCHES-CHAIN` | Already calibrated (consumer hazard) |

Per the spec's stop condition, the autonomous loop ends this
iteration.

## Test plan

- [x] `go test ./...` passes
- [x] `tools/audit/run_audit.sh` runs end-to-end on the 800-disk corpus
- [x] Fresh `recommendations.md` reflects the demote / line-0 / dialect-scope fixes
- [x] Source-grounded commit messages (samdos / ROM / masterdos source line ranges)
- [ ] CI green (will monitor and fix autonomously)

🤖 Generated with [Claude Code](https://claude.com/claude-code)